### PR TITLE
fix: convert exception to string before comparison in Internal Server Error check

### DIFF
--- a/youdub/step030_translation.py
+++ b/youdub/step030_translation.py
@@ -293,7 +293,7 @@ def _translate(summary, transcript, target_language='简体中文'):
                 break
             except Exception as e:
                 logger.error(e)
-                if e == 'Internal Server Error':
+                if str(e) == 'Internal Server Error':
                     client = OpenAI(
                         # This is the default and can be omitted
                         base_url=os.getenv(


### PR DESCRIPTION
## Summary

Fixes a bug in `youdub/step030_translation.py` where an `Exception` object is compared to a string using `==`, which always returns `False` in Python.

## Problem

In the translation retry loop:

```python
except Exception as e:
    logger.error(e)
    if e == 'Internal Server Error':  # ← Always False!
        client = OpenAI(...)
```

Since `e` is an `Exception` instance (not a string), the comparison `e == 'Internal Server Error'` always evaluates to `False`. This means the OpenAI client is **never** re-initialized when an Internal Server Error occurs, causing all retries to fail without recovery.

## Fix

```python
if str(e) == 'Internal Server Error':
```

Converting the exception to a string before comparison correctly detects the error message and allows the client to be re-initialized as intended.

Closes #56