### PR TITLE
docs: 补充跨平台说明并修复开发检查

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -66,21 +66,56 @@ https://github.com/user-attachments/assets/158de60a-7de4-4ddf-b3d8-478d0423aee6
 
 ### 1. Prepare the runtime
 
-Recommended environment:
+Verified and recommended runtime:
 
-- Python 3.12
-- Node.js 20+
-- FFmpeg / ffprobe
-- CUDA GPU. CPU can be configured, but full video processing will be slow.
+- **Windows 10/11 + PowerShell 5.1+**: recommended for local development and covered first in this README.
+- **Linux / WSL2 / macOS**: backend and frontend commands are provided for POSIX shells. CUDA, FFmpeg, PyTorch, and audio dependencies still need to match your platform.
+- **CUDA GPU**: recommended for complete video processing. `DEVICE=cpu` can be used for some flows, but transcription, separation, and TTS will be very slow.
+
+Base dependencies:
+
+- Python 3.12.
+- Node.js 20+.
+- FFmpeg / ffprobe available on `PATH`.
 - A working YouTube proxy when processing YouTube videos.
 - Netscape-format YouTube cookies, recommended for YouTube videos.
 - An OpenAI-compatible Chat Completions base URL, API key, and model name.
 
 The first run may download or load large ASR, TTS, and audio-processing models. Leave enough disk space and time for that setup.
 
-### 2. Clone
+Platform notes:
+
+- Windows PowerShell uses `.venv\Scripts\...`; do not copy `.venv/bin/...` commands there.
+- macOS/Linux use `.venv/bin/...`.
+- If multiple Python installs exist, check `py -0p` on Windows or `python3.12 --version` on macOS/Linux first.
+- Proxy settings, cookies, model cache, and work folders stay local. Quote paths that contain spaces, or put them in `.env`.
+
+Common system dependency examples:
+
+```powershell
+# Windows PowerShell (choose a package manager already available on your machine)
+winget install Gyan.FFmpeg
+winget install OpenJS.NodeJS.LTS
+```
 
 ```bash
+# Ubuntu / Debian / WSL2
+sudo apt update
+sudo apt install -y ffmpeg nodejs npm
+```
+
+```bash
+# macOS (Homebrew)
+brew install ffmpeg node
+```
+
+If your system package manager does not provide Python 3.12, install it from python.org, pyenv, conda/mamba, or your distro's recommended channel. The important part is to create the virtual environment with Python 3.12.
+
+### 2. Clone
+
+The clone commands are the same on Windows PowerShell, macOS, and Linux:
+
+```powershell
 git clone https://github.com/liuzhao1225/YouDub-webui.git
 cd YouDub-webui
 git submodule update --init --recursive
@@ -90,10 +125,29 @@ Demucs is included as a source submodule, so do not skip `git submodule update`.
 
 ### 3. Install dependencies
 
+#### Windows PowerShell
+
+Python:
+
+```powershell
+py -3.12 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -U pip
+.\.venv\Scripts\pip.exe install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
+```
+
+Frontend:
+
+```powershell
+npm --prefix apps/web install --registry=https://registry.npmmirror.com
+```
+
+#### macOS / Linux / WSL2
+
 Python:
 
 ```bash
 python3.12 -m venv .venv
+.venv/bin/python -m pip install -U pip
 .venv/bin/pip install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -106,6 +160,14 @@ npm --prefix apps/web install --registry=https://registry.npmmirror.com
 Use Aliyun first. If a specific Python package is temporarily unavailable there, retry only that package with the Tsinghua mirror instead of mixing multiple mirrors in one resolver command.
 
 ### 4. Configure
+
+Windows PowerShell:
+
+```powershell
+Copy-Item env.txt.example .env
+```
+
+macOS / Linux / WSL2:
 
 ```bash
 cp env.txt.example .env
@@ -134,6 +196,22 @@ Common localhost, LAN, and Tailscale `:3000` frontend origins are allowed by def
 
 ### 5. Run
 
+#### Windows PowerShell
+
+Backend:
+
+```powershell
+.\.venv\Scripts\uvicorn.exe backend.app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+Frontend:
+
+```powershell
+npm --prefix apps/web run dev -- --hostname 0.0.0.0 --port 3000
+```
+
+#### macOS / Linux / WSL2
+
 Backend:
 
 ```bash
@@ -151,6 +229,8 @@ Open:
 ```text
 http://localhost:3000
 ```
+
+When opening the app from LAN, WSL2, or another machine, use the actual frontend host IP or hostname, for example `http://192.168.1.20:3000`. The backend listens on `0.0.0.0:8000`, and the frontend listens on `0.0.0.0:3000`.
 
 ## Using the Web UI
 
@@ -218,13 +298,21 @@ YouTube / Bilibili URL
 
 Backend tests:
 
+Windows PowerShell:
+
+```powershell
+.\.venv\Scripts\pytest.exe backend/tests
+```
+
+macOS / Linux / WSL2:
+
 ```bash
 .venv/bin/pytest backend/tests
 ```
 
 Frontend checks:
 
-```bash
+```powershell
 npm --prefix apps/web run lint
 npm --prefix apps/web run build
 ```

--- a/README.md
+++ b/README.md
@@ -66,21 +66,56 @@ https://github.com/user-attachments/assets/158de60a-7de4-4ddf-b3d8-478d0423aee6
 
 ### 1. 准备运行环境
 
-建议环境：
+已验证和推荐的运行方式：
 
-- Python 3.12
-- Node.js 20+
-- FFmpeg / ffprobe
-- CUDA GPU（CPU 可配置，但完整视频处理会很慢）
+- **Windows 10/11 + PowerShell 5.1+**：推荐开发环境，也是本文档优先覆盖的平台。
+- **Linux / WSL2 / macOS**：后端和前端命令按 POSIX shell 给出；CUDA、FFmpeg、PyTorch/音频依赖需要按各平台实际环境安装。
+- **CUDA GPU**：推荐用于完整视频处理。`DEVICE=cpu` 可以运行部分流程，但完整转写、分离、TTS 会非常慢。
+
+基础依赖：
+
+- Python 3.12。
+- Node.js 20+。
+- FFmpeg / ffprobe，并确保命令在 `PATH` 中可用。
 - 可访问 YouTube 的代理（处理 YouTube 视频时需要）
 - Netscape 格式的 YouTube Cookie（处理 YouTube 视频时推荐配置）
 - OpenAI 兼容 Chat Completions API 的 base URL、API key 和模型名
 
 首次运行会下载或加载较大的 ASR、TTS、音频处理模型，请预留磁盘空间和网络时间。
 
-### 2. 克隆项目
+平台注意事项：
+
+- Windows PowerShell 使用 `.venv\Scripts\...`，不要照抄 `.venv/bin/...`。
+- macOS/Linux 使用 `.venv/bin/...`。
+- 如果系统里同时存在多个 Python，请先确认 `py -0p`（Windows）或 `python3.12 --version`（macOS/Linux）的结果。
+- 代理、Cookie、模型缓存和工作目录都保存在本机；路径中含空格时，建议使用引号或写入 `.env`。
+
+常见系统依赖安装示例：
+
+```powershell
+# Windows PowerShell（任选你本机已有的包管理器）
+winget install Gyan.FFmpeg
+winget install OpenJS.NodeJS.LTS
+```
 
 ```bash
+# Ubuntu / Debian / WSL2
+sudo apt update
+sudo apt install -y ffmpeg nodejs npm
+```
+
+```bash
+# macOS（Homebrew）
+brew install ffmpeg node
+```
+
+如果你的系统包管理器无法提供 Python 3.12，建议从 Python 官网、pyenv、conda/mamba 或发行版推荐方式安装；关键是后续创建虚拟环境时确认使用的是 3.12。
+
+### 2. 克隆项目
+
+Windows PowerShell、macOS 和 Linux 通用：
+
+```powershell
 git clone https://github.com/liuzhao1225/YouDub-webui.git
 cd YouDub-webui
 git submodule update --init --recursive
@@ -90,10 +125,29 @@ Demucs 以源码子模块引入，请不要跳过 `git submodule update`。
 
 ### 3. 安装依赖
 
+#### Windows PowerShell
+
+Python 依赖：
+
+```powershell
+py -3.12 -m venv .venv
+.\.venv\Scripts\python.exe -m pip install -U pip
+.\.venv\Scripts\pip.exe install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
+```
+
+前端依赖：
+
+```powershell
+npm --prefix apps/web install --registry=https://registry.npmmirror.com
+```
+
+#### macOS / Linux / WSL2
+
 Python 依赖：
 
 ```bash
 python3.12 -m venv .venv
+.venv/bin/python -m pip install -U pip
 .venv/bin/pip install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -106,6 +160,14 @@ npm --prefix apps/web install --registry=https://registry.npmmirror.com
 如果 Aliyun 镜像中某个 Python 包暂时不可用，再单独对失败的包使用 Tsinghua 源重试；不要把多个镜像混在同一条 resolver 命令里。
 
 ### 4. 配置环境
+
+Windows PowerShell：
+
+```powershell
+Copy-Item env.txt.example .env
+```
+
+macOS / Linux / WSL2：
 
 ```bash
 cp env.txt.example .env
@@ -134,6 +196,22 @@ cp env.txt.example .env
 
 ### 5. 启动服务
 
+#### Windows PowerShell
+
+后端：
+
+```powershell
+.\.venv\Scripts\uvicorn.exe backend.app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+前端：
+
+```powershell
+npm --prefix apps/web run dev -- --hostname 0.0.0.0 --port 3000
+```
+
+#### macOS / Linux / WSL2
+
 后端：
 
 ```bash
@@ -151,6 +229,8 @@ npm --prefix apps/web run dev -- --hostname 0.0.0.0 --port 3000
 ```text
 http://localhost:3000
 ```
+
+如果从局域网、WSL2 或远程机器访问，浏览器里使用运行前端机器的实际 IP 或主机名，例如 `http://192.168.1.20:3000`。后端默认监听 `0.0.0.0:8000`，前端默认监听 `0.0.0.0:3000`。
 
 ## 页面里怎么用
 
@@ -218,13 +298,21 @@ YouTube / Bilibili URL
 
 后端测试：
 
+Windows PowerShell：
+
+```powershell
+.\.venv\Scripts\pytest.exe backend/tests
+```
+
+macOS / Linux / WSL2：
+
 ```bash
 .venv/bin/pytest backend/tests
 ```
 
 前端检查：
 
-```bash
+```powershell
 npm --prefix apps/web run lint
 npm --prefix apps/web run build
 ```

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -57,12 +57,23 @@ export default function Home() {
   }, [])
 
   useEffect(() => {
-    refreshTasks().catch((err) => setError(err.message))
-    const interval = window.setInterval(() => {
-      refreshTasks().catch((err) => setError(err.message))
-    }, 2000)
-    return () => window.clearInterval(interval)
-  }, [refreshTasks])
+    let cancelled = false
+    const load = async () => {
+      try {
+        const { tasks: list } = await listTasks()
+        if (cancelled) return
+        setTasks(list)
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load tasks")
+      }
+    }
+    load()
+    const interval = window.setInterval(load, 2000)
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
+  }, [])
 
   async function submitTask(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "youdub-webui-fullstack",
   "private": true,
   "scripts": {
-    "dev:api": "CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-1} uvicorn backend.app.main:app --reload --host 0.0.0.0 --port 8000",
+    "dev:api": "uvicorn backend.app.main:app --reload --host 0.0.0.0 --port 8000",
     "dev:web": "npm --prefix apps/web run dev",
     "test:backend": "pytest backend/tests",
     "lint:web": "npm --prefix apps/web run lint",


### PR DESCRIPTION
## 变更内容

- 在中文和英文 README 中补充 Windows PowerShell、macOS、Linux、WSL2 的安装、配置、启动和测试命令。
- 明确 Windows `.venv\Scripts\...` 与 macOS/Linux `.venv/bin/...` 的虚拟环境路径差异。
- 补充 FFmpeg、Node.js 等系统依赖在常见平台上的安装示例。
- 增加局域网、WSL2 或远程机器访问前端时使用实际 IP/主机名的说明。
- 修复首页任务轮询触发的 `react-hooks/set-state-in-effect` lint 报错，保留首次加载和 2 秒轮询行为。
- 将根目录 `dev:api` 脚本改为跨平台的 `uvicorn` 启动命令，避免 Windows 下依赖 POSIX shell 变量展开。

## 背景

原 README 中的快速开始命令主要偏向 POSIX shell，新用户在 Windows PowerShell 或 WSL2 等环境下容易直接复制失败。本次变更把平台相关命令拆开，并同步修复开发脚本和前端 lint 问题，降低首次运行和提交检查的踩坑成本。

## 验证

- 已运行 `git diff origin/main..HEAD --check`，没有发现空白格式问题。
- 已运行 `npm --prefix apps/web run lint`，通过。
- 已运行 `npm --prefix apps/web run build`，通过。