### PR TITLE
feat: 添加可切换的中文界面

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { LanguageProvider } from "@/lib/i18n";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,7 +28,9 @@ export default function RootLayout({
       lang="zh-CN"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <LanguageProvider>{children}</LanguageProvider>
+      </body>
     </html>
   );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   createTask,
   listTasks,
 } from "@/lib/api"
+import { useI18n } from "@/lib/i18n"
 import { statusBadgeClass } from "@/lib/status"
 import { AppHeader } from "@/components/app-header"
 import { Badge } from "@/components/ui/badge"
@@ -45,6 +46,7 @@ function activeCount(tasks: TaskSummary[]) {
 
 export default function Home() {
   const router = useRouter()
+  const { activeTasksText, stageLabel, statusLabel, t } = useI18n()
   const [youtubeUrl, setYoutubeUrl] = useState("")
   const [bilibiliUrl, setBilibiliUrl] = useState("")
   const [tasks, setTasks] = useState<TaskSummary[]>([])
@@ -64,7 +66,7 @@ export default function Home() {
         if (cancelled) return
         setTasks(list)
       } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load tasks")
+        if (!cancelled) setError(err instanceof Error ? err.message : t.home.loadError)
       }
     }
     load()
@@ -73,7 +75,7 @@ export default function Home() {
       cancelled = true
       window.clearInterval(interval)
     }
-  }, [])
+  }, [t.home.loadError])
 
   async function submitTask(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -88,7 +90,7 @@ export default function Home() {
       refreshTasks().catch(() => undefined)
       router.push(`/tasks/${created.id}`)
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to create task")
+      setError(err instanceof Error ? err.message : t.home.createError)
     } finally {
       setSubmitting(false)
     }
@@ -104,12 +106,12 @@ export default function Home() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Create new task</CardTitle>
+            <CardTitle>{t.home.createTitle}</CardTitle>
           </CardHeader>
           <CardContent>
             <form onSubmit={submitTask} className="space-y-4">
               <div className="space-y-2">
-                <Label htmlFor="youtube-url">YouTube URL (English → Chinese)</Label>
+                <Label htmlFor="youtube-url">{t.home.youtubeLabel}</Label>
                 <Input
                   id="youtube-url"
                   value={youtubeUrl}
@@ -119,7 +121,7 @@ export default function Home() {
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="bilibili-url">Bilibili URL (Chinese → English)</Label>
+                <Label htmlFor="bilibili-url">{t.home.bilibiliLabel}</Label>
                 <Input
                   id="bilibili-url"
                   value={bilibiliUrl}
@@ -131,14 +133,14 @@ export default function Home() {
               <div className="flex items-center justify-between gap-3">
                 {queued > 0 ? (
                   <p className="text-xs text-muted-foreground">
-                    {queued} task{queued > 1 ? "s" : ""} queued / running
+                    {activeTasksText(queued)}
                   </p>
                 ) : (
                   <span />
                 )}
                 <Button type="submit" disabled={!canSubmit}>
                   <Play className="size-4" />
-                  {submitting ? "Submitting" : "Create task"}
+                  {submitting ? t.home.submitting : t.home.createTask}
                 </Button>
               </div>
             </form>
@@ -153,12 +155,12 @@ export default function Home() {
 
         <Card>
           <CardHeader>
-            <CardTitle>Task history ({tasks.length})</CardTitle>
+            <CardTitle>{t.home.taskHistory} ({tasks.length})</CardTitle>
           </CardHeader>
           <CardContent className="px-0">
             {tasks.length === 0 ? (
               <div className="px-6 py-12 text-center text-sm text-muted-foreground">
-                No tasks yet. Submit a YouTube or Bilibili URL above to start.
+                {t.home.empty}
               </div>
             ) : (
               <ScrollArea className="max-h-[70dvh]">
@@ -174,10 +176,10 @@ export default function Home() {
                             {item.title || shortUrl(item.url)}
                           </p>
                           <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-                            <Badge className={statusBadgeClass(item.status)}>{item.status}</Badge>
+                            <Badge className={statusBadgeClass(item.status)}>{statusLabel(item.status)}</Badge>
                             <span>{formatTime(item.created_at)}</span>
                             {isActive(item.status) && item.current_stage ? (
-                              <span>· {item.current_stage}</span>
+                              <span>· {stageLabel(item.current_stage)}</span>
                             ) : null}
                           </div>
                         </div>

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -25,6 +25,7 @@ import {
   rerunTask,
   resumeTask,
 } from "@/lib/api"
+import { useI18n } from "@/lib/i18n"
 import { statusBadgeClass } from "@/lib/status"
 import { AppHeader } from "@/components/app-header"
 import { Badge } from "@/components/ui/badge"
@@ -77,6 +78,7 @@ function durationOf(start: string | null, end: string | null) {
 export default function TaskDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
   const router = useRouter()
+  const { stageLabel, statusLabel, t } = useI18n()
   const [task, setTask] = useState<Task | null>(null)
   const [log, setLog] = useState("")
   const [error, setError] = useState("")
@@ -96,7 +98,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
       await deleteTask(id)
       router.replace("/")
     } catch (err) {
-      setDeleteError(err instanceof Error ? err.message : "Failed to delete task")
+      setDeleteError(err instanceof Error ? err.message : t.task.deleteError)
       setDeleting(false)
     }
   }
@@ -110,7 +112,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
       setTask(next)
       setLog("")
     } catch (err) {
-      setRerunError(err instanceof Error ? err.message : "Failed to rerun task")
+      setRerunError(err instanceof Error ? err.message : t.task.rerunError)
     } finally {
       setRerunning(false)
     }
@@ -123,7 +125,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
       const next = await resumeTask(id)
       setTask(next)
     } catch (err) {
-      setResumeError(err instanceof Error ? err.message : "Failed to resume task")
+      setResumeError(err instanceof Error ? err.message : t.task.resumeError)
     } finally {
       setResuming(false)
     }
@@ -143,7 +145,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
         if (cancelled) return
         setLog(logText)
       } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load task")
+        if (!cancelled) setError(err instanceof Error ? err.message : t.task.loadError)
       }
     }
     load()
@@ -152,7 +154,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
       cancelled = true
       window.clearInterval(interval)
     }
-  }, [id])
+  }, [id, t.task.loadError])
 
   const progress = useMemo(() => {
     if (!task?.stages?.length) return 0
@@ -181,8 +183,8 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
         <Card>
           <CardHeader className="gap-3">
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <CardTitle>Task overview</CardTitle>
-              <Badge className={statusBadgeClass(task?.status)}>{task?.status || "loading"}</Badge>
+              <CardTitle>{t.task.overview}</CardTitle>
+              <Badge className={statusBadgeClass(task?.status)}>{statusLabel(task?.status)}</Badge>
             </div>
             <Progress value={progress} />
           </CardHeader>
@@ -191,7 +193,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
               <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-[120px_1fr]">
                 {task.title ? (
                   <>
-                    <dt className="text-muted-foreground">Title</dt>
+                    <dt className="text-muted-foreground">{t.task.title}</dt>
                     <dd className="break-words font-medium">{task.title}</dd>
                   </>
                 ) : null}
@@ -201,23 +203,23 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                     {task.url}
                   </a>
                 </dd>
-                <dt className="text-muted-foreground">Task ID</dt>
+                <dt className="text-muted-foreground">{t.task.taskId}</dt>
                 <dd className="font-mono text-xs">{task.id}</dd>
-                <dt className="text-muted-foreground">Created</dt>
+                <dt className="text-muted-foreground">{t.task.created}</dt>
                 <dd>{formatTime(task.created_at)}</dd>
-                <dt className="text-muted-foreground">Started</dt>
+                <dt className="text-muted-foreground">{t.task.started}</dt>
                 <dd>{formatTime(task.started_at)}</dd>
-                <dt className="text-muted-foreground">Completed</dt>
+                <dt className="text-muted-foreground">{t.task.completed}</dt>
                 <dd>{formatTime(task.completed_at) || "—"}</dd>
                 {task.session_path ? (
                   <>
-                    <dt className="text-muted-foreground">Session</dt>
+                    <dt className="text-muted-foreground">{t.task.session}</dt>
                     <dd className="break-all text-xs text-muted-foreground">{task.session_path}</dd>
                   </>
                 ) : null}
               </dl>
             ) : (
-              <div className="py-6 text-center text-sm text-muted-foreground">Loading task…</div>
+              <div className="py-6 text-center text-sm text-muted-foreground">{t.task.loading}</div>
             )}
           </CardContent>
         </Card>
@@ -225,7 +227,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
         {task?.status === "succeeded" && task.final_video_path ? (
           <Card>
             <CardHeader>
-              <CardTitle>Final video</CardTitle>
+              <CardTitle>{t.task.finalVideo}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
               <video
@@ -238,7 +240,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
               <p className="break-all text-xs text-muted-foreground">{task.final_video_path}</p>
               <Button nativeButton={false} render={<a href={finalVideoDownloadUrl(task.id)} />}>
                 <Download className="size-4" />
-                Download
+                {t.task.download}
               </Button>
             </CardContent>
           </Card>
@@ -246,7 +248,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
 
         <Card>
           <CardHeader>
-            <CardTitle>Stages</CardTitle>
+            <CardTitle>{t.task.stages}</CardTitle>
           </CardHeader>
           <CardContent>
             {task ? (
@@ -260,8 +262,8 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="text-xs text-muted-foreground">#{index + 1}</span>
-                        <p className="font-medium">{stage.label}</p>
-                        <Badge className={statusBadgeClass(stage.status)}>{stage.status}</Badge>
+                        <p className="font-medium">{stageLabel(stage.name, stage.label)}</p>
+                        <Badge className={statusBadgeClass(stage.status)}>{statusLabel(stage.status)}</Badge>
                         {stage.started_at ? (
                           <span className="text-xs text-muted-foreground">
                             {durationOf(stage.started_at, stage.completed_at)}
@@ -269,7 +271,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                         ) : null}
                       </div>
                       <p className="mt-1 text-sm text-muted-foreground">
-                        {stage.error_message || stage.last_message || "Waiting"}
+                        {stage.error_message || stage.last_message || t.common.waiting}
                       </p>
                     </div>
                   </li>
@@ -285,11 +287,11 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
             {isFailed ? (
               <div className="mt-4 flex flex-col gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-3 sm:flex-row sm:items-center sm:justify-between">
                 <p className="text-sm text-amber-800">
-                  Resume from the failed stage. Already-succeeded stages will be reused from cache.
+                  {t.task.resumeHelp}
                 </p>
                 <Button onClick={handleResume} disabled={resuming}>
                   {resuming ? <Loader2 className="size-4 animate-spin" /> : <Play className="size-4" />}
-                  {resuming ? "Resuming" : "Resume task"}
+                  {resuming ? t.task.resuming : t.task.resumeTask}
                 </Button>
               </div>
             ) : null}
@@ -303,7 +305,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
 
         <Card>
           <CardHeader className="flex flex-row items-center justify-between">
-            <CardTitle>Run log</CardTitle>
+            <CardTitle>{t.task.runLog}</CardTitle>
             <FileText className="size-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
@@ -311,7 +313,7 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
               {log ? (
                 <pre className="whitespace-pre-wrap break-words font-mono">{log}</pre>
               ) : (
-                <p className="text-zinc-400">Logs will appear once the task starts.</p>
+                <p className="text-zinc-400">{t.task.emptyLog}</p>
               )}
             </ScrollArea>
           </CardContent>
@@ -319,27 +321,27 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
 
         <Card className="border-red-200">
           <CardHeader>
-            <CardTitle className="text-red-700">Danger zone</CardTitle>
+            <CardTitle className="text-red-700">{t.task.dangerZone}</CardTitle>
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-muted-foreground">
-                Wipe the session directory and run this URL again from scratch.
+                {t.task.rerunHelp}
               </p>
               <Dialog open={rerunOpen} onOpenChange={setRerunOpen}>
                 <DialogTrigger
                   render={
                     <Button variant="outline" disabled={!task || isRunning}>
                       <RotateCw className="size-4" />
-                      Rerun task
+                      {t.task.rerunTask}
                     </Button>
                   }
                 />
                 <DialogContent>
                   <DialogHeader>
-                    <DialogTitle>Rerun this task?</DialogTitle>
+                    <DialogTitle>{t.task.rerunTitle}</DialogTitle>
                     <DialogDescription>
-                      Existing log, session directory and final video will be deleted, then the same URL is re-queued under the same task id.
+                      {t.task.rerunDescription}
                     </DialogDescription>
                   </DialogHeader>
                   {rerunError ? (
@@ -349,11 +351,11 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                   ) : null}
                   <DialogFooter>
                     <DialogClose render={<Button variant="outline" disabled={rerunning} />}>
-                      Cancel
+                      {t.common.cancel}
                     </DialogClose>
                     <Button onClick={handleRerun} disabled={rerunning}>
                       {rerunning ? <Loader2 className="size-4 animate-spin" /> : <RotateCw className="size-4" />}
-                      {rerunning ? "Rerunning" : "Confirm rerun"}
+                      {rerunning ? t.task.rerunning : t.task.confirmRerun}
                     </Button>
                   </DialogFooter>
                 </DialogContent>
@@ -361,22 +363,23 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
             </div>
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-muted-foreground">
-                Delete this task, its run log, and the entire session directory under <code className="font-mono text-xs">workfolder/</code>.
+                {t.task.deleteHelp} <code className="font-mono text-xs">workfolder/</code>
+                {t.common.sentenceEnd}
               </p>
               <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
                 <DialogTrigger
                   render={
                     <Button variant="destructive" disabled={!task || isRunning}>
                       <Trash2 className="size-4" />
-                      Delete task
+                      {t.task.deleteTask}
                     </Button>
                   }
                 />
                 <DialogContent>
                   <DialogHeader>
-                    <DialogTitle>Delete this task?</DialogTitle>
+                    <DialogTitle>{t.task.deleteTitle}</DialogTitle>
                     <DialogDescription>
-                      This permanently removes the task record, its log file, and the entire session directory. This action cannot be undone.
+                      {t.task.deleteDescription}
                     </DialogDescription>
                   </DialogHeader>
                   {deleteError ? (
@@ -386,18 +389,18 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
                   ) : null}
                   <DialogFooter>
                     <DialogClose render={<Button variant="outline" disabled={deleting} />}>
-                      Cancel
+                      {t.common.cancel}
                     </DialogClose>
                     <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
                       {deleting ? <Loader2 className="size-4 animate-spin" /> : <Trash2 className="size-4" />}
-                      {deleting ? "Deleting" : "Confirm delete"}
+                      {deleting ? t.task.deleting : t.task.confirmDelete}
                     </Button>
                   </DialogFooter>
                 </DialogContent>
               </Dialog>
             </div>
             {isRunning ? (
-              <p className="text-xs text-amber-600">Running tasks cannot be rerun or deleted. Wait until it finishes or fails.</p>
+              <p className="text-xs text-amber-600">{t.task.runningLocked}</p>
             ) : null}
           </CardContent>
         </Card>

--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -5,8 +5,11 @@ import { ArrowLeft } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import { SettingsDialog } from "@/components/settings-dialog"
+import { useI18n } from "@/lib/i18n"
 
 export function AppHeader({ backHref }: { backHref?: string }) {
+  const { t } = useI18n()
+
   return (
     <header className="flex flex-col gap-4 border-b border-[#00aeec]/25 pb-5 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-3">
@@ -15,7 +18,7 @@ export function AppHeader({ backHref }: { backHref?: string }) {
             variant="ghost"
             size="icon-sm"
             nativeButton={false}
-            render={<Link href={backHref} aria-label="Back" />}
+            render={<Link href={backHref} aria-label={t.common.back} />}
           >
             <ArrowLeft className="size-4" />
           </Button>

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -12,6 +12,7 @@ import {
   saveOpenAISettings,
   saveYtdlpSettings,
 } from "@/lib/api"
+import { LANGUAGE_OPTIONS, useI18n } from "@/lib/i18n"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -43,7 +44,6 @@ type SettingsForm = {
 }
 
 const SAVED_API_KEY_MASK = "********"
-const SAVED_COOKIE_MASK = "******** saved YouTube cookie ********"
 
 const defaultSettings: SettingsForm = {
   cookie: "",
@@ -59,6 +59,7 @@ function uniqueModels(models: string[]) {
 }
 
 export function SettingsDialog() {
+  const { language, loadedModelsText, setLanguage, t } = useI18n()
   const [open, setOpen] = useState(false)
   const [settings, setSettings] = useState(defaultSettings)
   const [message, setMessage] = useState("")
@@ -69,12 +70,14 @@ export function SettingsDialog() {
   const [cookieDirty, setCookieDirty] = useState(false)
   const [apiKeyDirty, setApiKeyDirty] = useState(false)
 
+  const savedCookieMask = t.settings.savedCookie
+
   useEffect(() => {
     if (!open) return
     Promise.all([getCookieInfo(), getOpenAISettings(), getYtdlpSettings()])
       .then(([cookie, openai, ytdlp]) => {
         setSettings({
-          cookie: cookie.exists ? SAVED_COOKIE_MASK : "",
+          cookie: cookie.exists ? savedCookieMask : "",
           baseUrl: openai.base_url,
           apiKey: openai.has_api_key ? openai.api_key || SAVED_API_KEY_MASK : "",
           model: openai.model,
@@ -86,10 +89,10 @@ export function SettingsDialog() {
         setShowApiKey(false)
         setCookieDirty(false)
         setApiKeyDirty(false)
-        setMessage(openai.has_api_key ? "OpenAI key is saved." : "")
+        setMessage(openai.has_api_key ? t.settings.keySaved : "")
       })
       .catch((err) => setMessage(err.message))
-  }, [open])
+  }, [open, savedCookieMask, t.settings.keySaved])
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -103,18 +106,18 @@ export function SettingsDialog() {
         translate_concurrency: settings.translateConcurrency,
       })
       const ytdlp = await saveYtdlpSettings({ proxy_port: settings.proxyPort })
-      setMessage("Settings saved.")
+      setMessage(t.settings.saved)
       setSettings((current) => ({
         ...current,
         apiKey: openai.has_api_key ? openai.api_key || SAVED_API_KEY_MASK : "",
-        cookie: cookieDirty ? (cookie?.exists ? SAVED_COOKIE_MASK : "") : current.cookie,
+        cookie: cookieDirty ? (cookie?.exists ? savedCookieMask : "") : current.cookie,
         translateConcurrency: openai.translate_concurrency || current.translateConcurrency,
         proxyPort: ytdlp.proxy_port,
       }))
       setCookieDirty(false)
       setApiKeyDirty(false)
     } catch (err) {
-      setMessage(err instanceof Error ? err.message : "Failed to save settings")
+      setMessage(err instanceof Error ? err.message : t.settings.saveError)
     }
   }
 
@@ -130,9 +133,9 @@ export function SettingsDialog() {
       setModelOptions(models)
       setModelsLoaded(true)
       setSettings((current) => ({ ...current, model: current.model || models[0] || "" }))
-      setMessage(models.length ? `${models.length} models loaded.` : "No models returned.")
+      setMessage(models.length ? loadedModelsText(models.length) : t.settings.noModels)
     } catch (err) {
-      setMessage(err instanceof Error ? err.message : "Failed to load models")
+      setMessage(err instanceof Error ? err.message : t.settings.loadModelsError)
     } finally {
       setModelsLoading(false)
     }
@@ -142,23 +145,43 @@ export function SettingsDialog() {
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger render={<Button variant="outline" />}>
         <Settings className="size-4" />
-        Settings
+        {t.settings.button}
       </DialogTrigger>
       <DialogContent className="max-h-[calc(100dvh-2rem)] overflow-hidden sm:max-w-2xl">
         <form onSubmit={submit} className="flex max-h-[calc(100dvh-4rem)] min-h-0 flex-col">
           <DialogHeader className="shrink-0 pr-8">
-            <DialogTitle>Runtime settings</DialogTitle>
-            <DialogDescription>Stored locally by the FastAPI backend.</DialogDescription>
+            <DialogTitle>{t.settings.title}</DialogTitle>
+            <DialogDescription>{t.settings.description}</DialogDescription>
           </DialogHeader>
           <div className="mt-4 min-h-0 overflow-y-auto pr-1">
             <div className="grid gap-4 pb-4">
               <div className="grid gap-2">
-                <Label htmlFor="cookie">YouTube cookie</Label>
+                <Label htmlFor="uiLanguage">{t.settings.language}</Label>
+                <Select
+                  value={language}
+                  onValueChange={(value) => {
+                    if (value === "en" || value === "zh") setLanguage(value)
+                  }}
+                >
+                  <SelectTrigger id="uiLanguage">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LANGUAGE_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="cookie">{t.settings.cookie}</Label>
                 <Textarea
                   id="cookie"
                   value={settings.cookie}
                   onFocus={(event) => {
-                    if (!cookieDirty && settings.cookie === SAVED_COOKIE_MASK) {
+                    if (!cookieDirty && settings.cookie === savedCookieMask) {
                       event.currentTarget.select()
                     }
                   }}
@@ -166,15 +189,15 @@ export function SettingsDialog() {
                     setCookieDirty(true)
                     setSettings((current) => ({
                       ...current,
-                      cookie: event.target.value.replace(SAVED_COOKIE_MASK, ""),
+                      cookie: event.target.value.replace(savedCookieMask, ""),
                     }))
                   }}
-                  placeholder="Paste Netscape cookie content"
+                  placeholder={t.settings.cookiePlaceholder}
                   className="min-h-44 max-h-[42dvh] overflow-auto font-mono text-xs leading-relaxed"
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="proxyPort">yt-dlp proxy port</Label>
+                <Label htmlFor="proxyPort">{t.settings.proxyPort}</Label>
                 <Input
                   id="proxyPort"
                   inputMode="numeric"
@@ -186,7 +209,7 @@ export function SettingsDialog() {
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="baseUrl">OpenAI base URL</Label>
+                <Label htmlFor="baseUrl">{t.settings.baseUrl}</Label>
                 <Input
                   id="baseUrl"
                   value={settings.baseUrl}
@@ -196,7 +219,7 @@ export function SettingsDialog() {
                 />
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="apiKey">OpenAI API key</Label>
+                <Label htmlFor="apiKey">{t.settings.apiKey}</Label>
                 <div className="relative">
                   <Input
                     id="apiKey"
@@ -214,7 +237,7 @@ export function SettingsDialog() {
                         apiKey: event.target.value.replace(SAVED_API_KEY_MASK, ""),
                       }))
                     }}
-                    placeholder="Leave blank to keep existing key"
+                    placeholder={t.settings.apiKeyPlaceholder}
                     className="pr-9"
                   />
                   <Button
@@ -225,13 +248,13 @@ export function SettingsDialog() {
                     onClick={() => setShowApiKey((current) => !current)}
                   >
                     {showApiKey ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-                    <span className="sr-only">{showApiKey ? "Hide API key" : "Show API key"}</span>
+                    <span className="sr-only">{showApiKey ? t.settings.hideApiKey : t.settings.showApiKey}</span>
                   </Button>
                 </div>
               </div>
               <div className="grid gap-2 sm:grid-cols-[1fr_auto]">
                 <div className="grid gap-2">
-                  <Label htmlFor="model">Model</Label>
+                  <Label htmlFor="model">{t.settings.model}</Label>
                   {modelsLoaded && modelOptions.length > 0 ? (
                     <Select
                       value={settings.model}
@@ -240,7 +263,7 @@ export function SettingsDialog() {
                       }
                     >
                       <SelectTrigger id="model">
-                        <SelectValue placeholder="Select model" />
+                        <SelectValue placeholder={t.settings.selectModel} />
                       </SelectTrigger>
                       <SelectContent>
                         {modelOptions.map((model) => (
@@ -268,12 +291,12 @@ export function SettingsDialog() {
                     disabled={modelsLoading || !settings.baseUrl.trim()}
                   >
                     <RefreshCw className="size-4" />
-                    {modelsLoading ? "Loading" : "Get models"}
+                    {modelsLoading ? t.settings.loading : t.settings.getModels}
                   </Button>
                 </div>
               </div>
               <div className="grid gap-2">
-                <Label htmlFor="translateConcurrency">Translate concurrency</Label>
+                <Label htmlFor="translateConcurrency">{t.settings.translateConcurrency}</Label>
                 <Input
                   id="translateConcurrency"
                   inputMode="numeric"
@@ -287,14 +310,14 @@ export function SettingsDialog() {
                   placeholder="50"
                 />
                 <p className="text-xs text-muted-foreground">
-                  Parallel OpenAI requests during the translate stage. Increase if your provider allows it.
+                  {t.settings.concurrencyHelp}
                 </p>
               </div>
               {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
             </div>
           </div>
           <DialogFooter className="shrink-0">
-            <Button type="submit">Save settings</Button>
+            <Button type="submit">{t.settings.save}</Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/apps/web/src/components/settings-dialog.tsx
+++ b/apps/web/src/components/settings-dialog.tsx
@@ -44,6 +44,9 @@ type SettingsForm = {
 }
 
 const SAVED_API_KEY_MASK = "********"
+const SAVED_COOKIE_SENTINEL = "__YOUDUB_SAVED_COOKIE__"
+
+type MessageKey = "keySaved" | "saved"
 
 const defaultSettings: SettingsForm = {
   cookie: "",
@@ -63,6 +66,7 @@ export function SettingsDialog() {
   const [open, setOpen] = useState(false)
   const [settings, setSettings] = useState(defaultSettings)
   const [message, setMessage] = useState("")
+  const [messageKey, setMessageKey] = useState<MessageKey | null>(null)
   const [modelOptions, setModelOptions] = useState<string[]>([])
   const [modelsLoaded, setModelsLoaded] = useState(false)
   const [modelsLoading, setModelsLoading] = useState(false)
@@ -70,14 +74,17 @@ export function SettingsDialog() {
   const [cookieDirty, setCookieDirty] = useState(false)
   const [apiKeyDirty, setApiKeyDirty] = useState(false)
 
-  const savedCookieMask = t.settings.savedCookie
+  const cookieValue =
+    settings.cookie === SAVED_COOKIE_SENTINEL ? t.settings.savedCookie : settings.cookie
+  const visibleMessage =
+    messageKey === "keySaved" ? t.settings.keySaved : messageKey === "saved" ? t.settings.saved : message
 
   useEffect(() => {
     if (!open) return
     Promise.all([getCookieInfo(), getOpenAISettings(), getYtdlpSettings()])
       .then(([cookie, openai, ytdlp]) => {
         setSettings({
-          cookie: cookie.exists ? savedCookieMask : "",
+          cookie: cookie.exists ? SAVED_COOKIE_SENTINEL : "",
           baseUrl: openai.base_url,
           apiKey: openai.has_api_key ? openai.api_key || SAVED_API_KEY_MASK : "",
           model: openai.model,
@@ -89,14 +96,19 @@ export function SettingsDialog() {
         setShowApiKey(false)
         setCookieDirty(false)
         setApiKeyDirty(false)
-        setMessage(openai.has_api_key ? t.settings.keySaved : "")
+        setMessage("")
+        setMessageKey(openai.has_api_key ? "keySaved" : null)
       })
-      .catch((err) => setMessage(err.message))
-  }, [open, savedCookieMask, t.settings.keySaved])
+      .catch((err) => {
+        setMessageKey(null)
+        setMessage(err.message)
+      })
+  }, [open])
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     setMessage("")
+    setMessageKey(null)
     try {
       const cookie = cookieDirty ? await saveCookie(settings.cookie) : null
       const openai = await saveOpenAISettings({
@@ -106,23 +118,25 @@ export function SettingsDialog() {
         translate_concurrency: settings.translateConcurrency,
       })
       const ytdlp = await saveYtdlpSettings({ proxy_port: settings.proxyPort })
-      setMessage(t.settings.saved)
+      setMessageKey("saved")
       setSettings((current) => ({
         ...current,
         apiKey: openai.has_api_key ? openai.api_key || SAVED_API_KEY_MASK : "",
-        cookie: cookieDirty ? (cookie?.exists ? savedCookieMask : "") : current.cookie,
+        cookie: cookieDirty ? (cookie?.exists ? SAVED_COOKIE_SENTINEL : "") : current.cookie,
         translateConcurrency: openai.translate_concurrency || current.translateConcurrency,
         proxyPort: ytdlp.proxy_port,
       }))
       setCookieDirty(false)
       setApiKeyDirty(false)
     } catch (err) {
+      setMessageKey(null)
       setMessage(err instanceof Error ? err.message : t.settings.saveError)
     }
   }
 
   async function fetchModels() {
     setMessage("")
+    setMessageKey(null)
     setModelsLoading(true)
     try {
       const response = await getOpenAIModels({
@@ -135,6 +149,7 @@ export function SettingsDialog() {
       setSettings((current) => ({ ...current, model: current.model || models[0] || "" }))
       setMessage(models.length ? loadedModelsText(models.length) : t.settings.noModels)
     } catch (err) {
+      setMessageKey(null)
       setMessage(err instanceof Error ? err.message : t.settings.loadModelsError)
     } finally {
       setModelsLoading(false)
@@ -179,9 +194,9 @@ export function SettingsDialog() {
                 <Label htmlFor="cookie">{t.settings.cookie}</Label>
                 <Textarea
                   id="cookie"
-                  value={settings.cookie}
+                  value={cookieValue}
                   onFocus={(event) => {
-                    if (!cookieDirty && settings.cookie === savedCookieMask) {
+                    if (!cookieDirty && settings.cookie === SAVED_COOKIE_SENTINEL) {
                       event.currentTarget.select()
                     }
                   }}
@@ -189,7 +204,10 @@ export function SettingsDialog() {
                     setCookieDirty(true)
                     setSettings((current) => ({
                       ...current,
-                      cookie: event.target.value.replace(savedCookieMask, ""),
+                      cookie:
+                        current.cookie === SAVED_COOKIE_SENTINEL
+                          ? event.target.value.replace(t.settings.savedCookie, "")
+                          : event.target.value,
                     }))
                   }}
                   placeholder={t.settings.cookiePlaceholder}
@@ -313,7 +331,7 @@ export function SettingsDialog() {
                   {t.settings.concurrencyHelp}
                 </p>
               </div>
-              {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+              {visibleMessage ? <p className="text-sm text-muted-foreground">{visibleMessage}</p> : null}
             </div>
           </div>
           <DialogFooter className="shrink-0">

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { XIcon } from "lucide-react"
+import { useI18n } from "@/lib/i18n"
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
@@ -47,6 +48,8 @@ function DialogContent({
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
 }) {
+  const { t } = useI18n()
+
   return (
     <DialogPortal>
       <DialogOverlay />
@@ -72,7 +75,7 @@ function DialogContent({
           >
             <XIcon
             />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t.common.close}</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
@@ -98,6 +101,8 @@ function DialogFooter({
 }: React.ComponentProps<"div"> & {
   showCloseButton?: boolean
 }) {
+  const { t } = useI18n()
+
   return (
     <div
       data-slot="dialog-footer"
@@ -110,7 +115,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
+          {t.common.close}
         </DialogPrimitive.Close>
       )}
     </div>

--- a/apps/web/src/lib/i18n.tsx
+++ b/apps/web/src/lib/i18n.tsx
@@ -261,7 +261,7 @@ function setDocumentLanguage(language: UiLanguage) {
 }
 
 export function LanguageProvider({ children }: { children: ReactNode }) {
-  const [language, setLanguageState] = useState<UiLanguage>("en")
+  const [language, setLanguageState] = useState<UiLanguage>("zh")
 
   useEffect(() => {
     const saved = window.localStorage.getItem(STORAGE_KEY)

--- a/apps/web/src/lib/i18n.tsx
+++ b/apps/web/src/lib/i18n.tsx
@@ -1,0 +1,313 @@
+"use client"
+
+import { createContext, ReactNode, useContext, useEffect, useMemo, useState } from "react"
+
+export type UiLanguage = "en" | "zh"
+
+const STORAGE_KEY = "youdub-ui-language"
+
+export const LANGUAGE_OPTIONS: { value: UiLanguage; label: string }[] = [
+  { value: "en", label: "English" },
+  { value: "zh", label: "中文" },
+]
+
+type Messages = {
+  common: {
+    back: string
+    cancel: string
+    close: string
+    loading: string
+    sentenceEnd: string
+    waiting: string
+  }
+  home: Record<string, string>
+  task: Record<string, string>
+  settings: Record<string, string>
+  status: Record<string, string>
+  stages: Record<string, string>
+}
+
+const messages: Record<UiLanguage, Messages> = {
+  en: {
+    common: {
+      back: "Back",
+      cancel: "Cancel",
+      close: "Close",
+      loading: "loading",
+      sentenceEnd: ".",
+      waiting: "Waiting",
+    },
+    home: {
+      createTitle: "Create new task",
+      youtubeLabel: "YouTube URL (English -> Chinese)",
+      bilibiliLabel: "Bilibili URL (Chinese -> English)",
+      submitting: "Submitting",
+      createTask: "Create task",
+      taskHistory: "Task history",
+      empty: "No tasks yet. Submit a YouTube or Bilibili URL above to start.",
+      loadError: "Failed to load tasks",
+      createError: "Failed to create task",
+    },
+    task: {
+      overview: "Task overview",
+      title: "Title",
+      taskId: "Task ID",
+      created: "Created",
+      started: "Started",
+      completed: "Completed",
+      session: "Session",
+      loading: "Loading task...",
+      finalVideo: "Final video",
+      download: "Download",
+      stages: "Stages",
+      resumeHelp: "Resume from the failed stage. Already-succeeded stages will be reused from cache.",
+      resuming: "Resuming",
+      resumeTask: "Resume task",
+      runLog: "Run log",
+      emptyLog: "Logs will appear once the task starts.",
+      dangerZone: "Danger zone",
+      rerunHelp: "Wipe the session directory and run this URL again from scratch.",
+      rerunTask: "Rerun task",
+      rerunTitle: "Rerun this task?",
+      rerunDescription:
+        "Existing log, session directory and final video will be deleted, then the same URL is re-queued under the same task id.",
+      rerunning: "Rerunning",
+      confirmRerun: "Confirm rerun",
+      deleteHelp:
+        "Delete this task, its run log, and the entire session directory under",
+      deleteTask: "Delete task",
+      deleteTitle: "Delete this task?",
+      deleteDescription:
+        "This permanently removes the task record, its log file, and the entire session directory. This action cannot be undone.",
+      deleting: "Deleting",
+      confirmDelete: "Confirm delete",
+      runningLocked: "Running tasks cannot be rerun or deleted. Wait until it finishes or fails.",
+      loadError: "Failed to load task",
+      deleteError: "Failed to delete task",
+      rerunError: "Failed to rerun task",
+      resumeError: "Failed to resume task",
+    },
+    settings: {
+      button: "Settings",
+      title: "Runtime settings",
+      description: "Stored locally by the FastAPI backend.",
+      language: "Interface language",
+      cookie: "YouTube cookie",
+      savedCookie: "******** saved YouTube cookie ********",
+      cookiePlaceholder: "Paste Netscape cookie content",
+      proxyPort: "yt-dlp proxy port",
+      baseUrl: "OpenAI base URL",
+      apiKey: "OpenAI API key",
+      apiKeyPlaceholder: "Leave blank to keep existing key",
+      hideApiKey: "Hide API key",
+      showApiKey: "Show API key",
+      model: "Model",
+      selectModel: "Select model",
+      loading: "Loading",
+      getModels: "Get models",
+      translateConcurrency: "Translate concurrency",
+      concurrencyHelp: "Parallel OpenAI requests during the translate stage. Increase if your provider allows it.",
+      save: "Save settings",
+      keySaved: "OpenAI key is saved.",
+      saved: "Settings saved.",
+      saveError: "Failed to save settings",
+      noModels: "No models returned.",
+      loadModelsError: "Failed to load models",
+    },
+    status: {
+      queued: "queued",
+      running: "running",
+      succeeded: "succeeded",
+      failed: "failed",
+      pending: "pending",
+    },
+    stages: {
+      download: "Download",
+      separate: "Demucs",
+      asr: "Whisper",
+      asr_fix: "Split sentences",
+      translate: "Translate",
+      split_audio: "Split audio",
+      tts: "VoxCPM",
+      merge_audio: "Merge audio",
+      merge_video: "Merge video",
+      done: "Done",
+    },
+  },
+  zh: {
+    common: {
+      back: "返回",
+      cancel: "取消",
+      close: "关闭",
+      loading: "加载中",
+      sentenceEnd: "。",
+      waiting: "等待中",
+    },
+    home: {
+      createTitle: "新建任务",
+      youtubeLabel: "YouTube 链接（英文 -> 中文）",
+      bilibiliLabel: "Bilibili 链接（中文 -> 英文）",
+      submitting: "提交中",
+      createTask: "创建任务",
+      taskHistory: "任务历史",
+      empty: "暂无任务。输入 YouTube 或 Bilibili 链接后即可开始。",
+      loadError: "加载任务失败",
+      createError: "创建任务失败",
+    },
+    task: {
+      overview: "任务概览",
+      title: "标题",
+      taskId: "任务 ID",
+      created: "创建时间",
+      started: "开始时间",
+      completed: "完成时间",
+      session: "会话目录",
+      loading: "正在加载任务...",
+      finalVideo: "最终视频",
+      download: "下载",
+      stages: "处理阶段",
+      resumeHelp: "从失败阶段继续执行。已经成功的阶段会复用缓存结果。",
+      resuming: "继续中",
+      resumeTask: "继续任务",
+      runLog: "运行日志",
+      emptyLog: "任务开始后会显示日志。",
+      dangerZone: "危险操作",
+      rerunHelp: "清空会话目录，并从头重新运行这个链接。",
+      rerunTask: "重跑任务",
+      rerunTitle: "确认重跑这个任务？",
+      rerunDescription:
+        "现有日志、会话目录和最终视频会被删除，然后使用同一个任务 ID 重新排队处理相同链接。",
+      rerunning: "重跑中",
+      confirmRerun: "确认重跑",
+      deleteHelp: "删除这个任务、运行日志，以及对应的整个会话目录：",
+      deleteTask: "删除任务",
+      deleteTitle: "确认删除这个任务？",
+      deleteDescription: "这会永久删除任务记录、日志文件和整个会话目录。此操作无法撤销。",
+      deleting: "删除中",
+      confirmDelete: "确认删除",
+      runningLocked: "运行中的任务不能重跑或删除，请等待任务完成或失败。",
+      loadError: "加载任务失败",
+      deleteError: "删除任务失败",
+      rerunError: "重跑任务失败",
+      resumeError: "继续任务失败",
+    },
+    settings: {
+      button: "设置",
+      title: "运行设置",
+      description: "设置会由 FastAPI 后端保存在本机。",
+      language: "界面语言",
+      cookie: "YouTube Cookie",
+      savedCookie: "******** 已保存 YouTube Cookie ********",
+      cookiePlaceholder: "粘贴 Netscape 格式 Cookie 内容",
+      proxyPort: "yt-dlp 代理端口",
+      baseUrl: "OpenAI Base URL",
+      apiKey: "OpenAI API Key",
+      apiKeyPlaceholder: "留空则保留现有 key",
+      hideApiKey: "隐藏 API key",
+      showApiKey: "显示 API key",
+      model: "模型",
+      selectModel: "选择模型",
+      loading: "加载中",
+      getModels: "获取模型",
+      translateConcurrency: "翻译并发数",
+      concurrencyHelp: "翻译阶段并行发起的 OpenAI 请求数。如果你的服务商允许，可以适当调高。",
+      save: "保存设置",
+      keySaved: "OpenAI API key 已保存。",
+      saved: "设置已保存。",
+      saveError: "保存设置失败",
+      noModels: "没有返回可用模型。",
+      loadModelsError: "加载模型失败",
+    },
+    status: {
+      queued: "排队中",
+      running: "运行中",
+      succeeded: "已完成",
+      failed: "失败",
+      pending: "等待中",
+    },
+    stages: {
+      download: "下载视频",
+      separate: "分离人声与背景音",
+      asr: "语音识别",
+      asr_fix: "切分句子",
+      translate: "翻译字幕",
+      split_audio: "切分音频",
+      tts: "生成配音",
+      merge_audio: "混合音频",
+      merge_video: "合成视频",
+      done: "已完成",
+    },
+  },
+}
+
+type LanguageContextValue = {
+  language: UiLanguage
+  setLanguage: (language: UiLanguage) => void
+  t: Messages
+  activeTasksText: (count: number) => string
+  loadedModelsText: (count: number) => string
+  statusLabel: (status?: string | null) => string
+  stageLabel: (name?: string | null, fallback?: string | null) => string
+}
+
+const LanguageContext = createContext<LanguageContextValue | null>(null)
+
+function isLanguage(value: string | null): value is UiLanguage {
+  return value === "en" || value === "zh"
+}
+
+function setDocumentLanguage(language: UiLanguage) {
+  document.documentElement.lang = language === "zh" ? "zh-CN" : "en"
+}
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguageState] = useState<UiLanguage>("en")
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem(STORAGE_KEY)
+    if (!isLanguage(saved)) return
+    window.setTimeout(() => setLanguageState(saved), 0)
+  }, [])
+
+  useEffect(() => {
+    setDocumentLanguage(language)
+  }, [language])
+
+  const value = useMemo<LanguageContextValue>(() => {
+    const t = messages[language]
+    return {
+      language,
+      setLanguage: (next) => {
+        setLanguageState(next)
+        window.localStorage.setItem(STORAGE_KEY, next)
+        setDocumentLanguage(next)
+      },
+      t,
+      activeTasksText: (count) =>
+        language === "zh"
+          ? `${count} 个任务正在排队或运行`
+          : `${count} task${count > 1 ? "s" : ""} queued / running`,
+      loadedModelsText: (count) =>
+        language === "zh" ? `已加载 ${count} 个模型。` : `${count} models loaded.`,
+      statusLabel: (status) => {
+        if (!status) return t.common.loading
+        return t.status[status as keyof typeof t.status] || status
+      },
+      stageLabel: (name, fallback) => {
+        if (name && name in t.stages) return t.stages[name as keyof typeof t.stages]
+        if (fallback && fallback in t.stages) return t.stages[fallback as keyof typeof t.stages]
+        return fallback || name || t.common.waiting
+      },
+    }
+  }, [language])
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>
+}
+
+export function useI18n() {
+  const context = useContext(LanguageContext)
+  if (!context) {
+    throw new Error("useI18n must be used inside LanguageProvider")
+  }
+  return context
+}


### PR DESCRIPTION
## 变更内容

- 新增轻量前端语言状态，默认中文，并将用户选择保存在浏览器 `localStorage`。
- 在设置弹窗中新增“Interface language / 界面语言”选项，可在 English 和 中文之间切换。
- 首页、任务详情页、设置弹窗、返回/关闭等通用文案会根据当前语言切换。
- 状态标签和流水线阶段名称在中文界面下显示为中文。

## 实现说明

- 不引入完整 i18n 框架，不改后端接口和数据库。
- 语言偏好仅存储在当前浏览器本地。

## 验证

- 已运行 `npm --prefix apps/web run lint`，通过。
- 已运行 `npm --prefix apps/web run build`；通过。