### PR TITLE
docs: 补充 CUDA 版 PyTorch 安装说明

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -136,6 +136,7 @@ Python:
 ```powershell
 py -3.12 -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
+.\.venv\Scripts\pip.exe install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .\.venv\Scripts\pip.exe install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -152,6 +153,7 @@ Python:
 ```bash
 python3.12 -m venv .venv
 .venv/bin/python -m pip install -U pip
+.venv/bin/pip install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .venv/bin/pip install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -162,6 +164,8 @@ npm --prefix apps/web install --registry=https://registry.npmmirror.com
 ```
 
 Use Aliyun first. If a specific Python package is temporarily unavailable there, retry only that package with the Tsinghua mirror instead of mixing multiple mirrors in one resolver command.
+
+`requirements-cuda.txt` installs a CUDA-enabled PyTorch build so local models such as Whisper, Demucs, and VoxCPM can use an NVIDIA GPU for inference. If you only use CPU inference, skip this step and install `requirements.txt` directly. The example command uses PyTorch's `cu128` wheel index by default; if you need a specific CUDA build, get the matching install command for your CUDA / driver environment from the [official PyTorch website](https://pytorch.org/).
 
 ### 4. Configure
 

--- a/README.en.md
+++ b/README.en.md
@@ -136,7 +136,6 @@ Python:
 ```powershell
 py -3.12 -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
-.\.venv\Scripts\pip.exe install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .\.venv\Scripts\pip.exe install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -153,7 +152,6 @@ Python:
 ```bash
 python3.12 -m venv .venv
 .venv/bin/python -m pip install -U pip
-.venv/bin/pip install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .venv/bin/pip install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -165,7 +163,29 @@ npm --prefix apps/web install --registry=https://registry.npmmirror.com
 
 Use Aliyun first. If a specific Python package is temporarily unavailable there, retry only that package with the Tsinghua mirror instead of mixing multiple mirrors in one resolver command.
 
-`requirements-cuda.txt` installs a CUDA-enabled PyTorch build so local models such as Whisper, Demucs, and VoxCPM can use an NVIDIA GPU for inference. If you only use CPU inference, skip this step and install `requirements.txt` directly. The example command uses PyTorch's `cu128` wheel index by default; if you need a specific CUDA build, get the matching install command for your CUDA / driver environment from the [official PyTorch website](https://pytorch.org/).
+#### Optional: NVIDIA CUDA GPU
+
+If you want Whisper, Demucs, or VoxCPM to use an NVIDIA GPU, install the CUDA-enabled PyTorch wheels before installing `requirements.txt`:
+
+Windows PowerShell:
+
+```powershell
+.\.venv\Scripts\pip.exe install -r requirements-pytorch-cu128.txt
+```
+
+Linux / WSL2:
+
+```bash
+.venv/bin/pip install -r requirements-pytorch-cu128.txt
+```
+
+`requirements-pytorch-cu128.txt` uses PyTorch's `cu128` wheel index by default. Different NVIDIA driver or CUDA environments may need a different PyTorch CUDA build, so use the [official PyTorch installation page](https://pytorch.org/get-started/locally/) when you need a matching command. CPU users and macOS users do not need this step; set `DEVICE=cpu` in `.env` when CUDA-enabled PyTorch is not installed.
+
+Verify that CUDA is actually available after installation:
+
+```bash
+.venv/bin/python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+```
 
 ### 4. Configure
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Python 依赖：
 ```powershell
 py -3.12 -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
+.\.venv\Scripts\pip.exe install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .\.venv\Scripts\pip.exe install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -152,6 +153,7 @@ Python 依赖：
 ```bash
 python3.12 -m venv .venv
 .venv/bin/python -m pip install -U pip
+.venv/bin/pip install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .venv/bin/pip install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -162,6 +164,8 @@ npm --prefix apps/web install --registry=https://registry.npmmirror.com
 ```
 
 如果 Aliyun 镜像中某个 Python 包暂时不可用，再单独对失败的包使用 Tsinghua 源重试；不要把多个镜像混在同一条 resolver 命令里。
+
+`requirements-cuda.txt` 用于安装支持 CUDA 的 PyTorch，以便 Whisper、Demucs 和 VoxCPM 等本地模型使用 NVIDIA GPU 推理。如果只使用 CPU 推理，可以跳过这一步，直接安装 `requirements.txt`。示例命令默认使用 PyTorch 的 `cu128` wheel 源；如果需要手动安装特定 CUDA 版本的 PyTorch，请根据您的 CUDA / 驱动环境从 [PyTorch 官方网站](https://pytorch.org/) 获取对应安装命令。
 
 ### 4. 配置环境
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ Python 依赖：
 ```powershell
 py -3.12 -m venv .venv
 .\.venv\Scripts\python.exe -m pip install -U pip
-.\.venv\Scripts\pip.exe install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .\.venv\Scripts\pip.exe install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -153,7 +152,6 @@ Python 依赖：
 ```bash
 python3.12 -m venv .venv
 .venv/bin/python -m pip install -U pip
-.venv/bin/pip install --index-url https://download.pytorch.org/whl/cu128 -r requirements-cuda.txt
 .venv/bin/pip install -i https://mirrors.aliyun.com/pypi/simple/ -r requirements.txt
 ```
 
@@ -165,7 +163,29 @@ npm --prefix apps/web install --registry=https://registry.npmmirror.com
 
 如果 Aliyun 镜像中某个 Python 包暂时不可用，再单独对失败的包使用 Tsinghua 源重试；不要把多个镜像混在同一条 resolver 命令里。
 
-`requirements-cuda.txt` 用于安装支持 CUDA 的 PyTorch，以便 Whisper、Demucs 和 VoxCPM 等本地模型使用 NVIDIA GPU 推理。如果只使用 CPU 推理，可以跳过这一步，直接安装 `requirements.txt`。示例命令默认使用 PyTorch 的 `cu128` wheel 源；如果需要手动安装特定 CUDA 版本的 PyTorch，请根据您的 CUDA / 驱动环境从 [PyTorch 官方网站](https://pytorch.org/) 获取对应安装命令。
+#### 可选：NVIDIA CUDA GPU
+
+如果要用 NVIDIA GPU 跑 Whisper、Demucs 或 VoxCPM，请在安装 `requirements.txt` 之前先安装 CUDA 版 PyTorch：
+
+Windows PowerShell：
+
+```powershell
+.\.venv\Scripts\pip.exe install -r requirements-pytorch-cu128.txt
+```
+
+Linux / WSL2：
+
+```bash
+.venv/bin/pip install -r requirements-pytorch-cu128.txt
+```
+
+`requirements-pytorch-cu128.txt` 默认使用 PyTorch 的 `cu128` wheel 源。不同 NVIDIA 驱动或 CUDA 环境可能需要不同的 PyTorch CUDA 版本，请按 [PyTorch 官方安装页](https://pytorch.org/get-started/locally/) 选择匹配命令。CPU 用户和 macOS 用户不需要执行这一步；如果没有安装 CUDA 版 PyTorch，请在 `.env` 中设置 `DEVICE=cpu`。
+
+安装后可以验证 CUDA 是否真的可用：
+
+```bash
+.venv/bin/python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+```
 
 ### 4. 配置环境
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from .adapters.local_video import remove_upload, upload_dir
 from .adapters.openai_translate import list_models as list_openai_models
 from .config import WORKFOLDER, YOUTUBE_COOKIE_PATH, ensure_runtime_dirs
 from .pipeline import run_task
+from .runtime_checks import validate_runtime_device
 from .sanitize import sanitize_text
 from .youtube import LOCAL_UPLOAD_DIRECTIONS, extract_video_id, is_local_upload_url
 
@@ -136,6 +137,13 @@ def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+def _ensure_runtime_ready() -> None:
+    try:
+        validate_runtime_device()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+
 @app.post("/api/tasks", status_code=201)
 def create_task(payload: TaskCreate) -> dict:
     try:
@@ -147,6 +155,7 @@ def create_task(payload: TaskCreate) -> dict:
     if existing_id:
         return database.get_task(existing_id)
 
+    _ensure_runtime_ready()
     task_id = database.create_task(payload.url.strip(), task_id=video_id)
     worker.enqueue(task_id)
     return database.get_task(task_id)
@@ -187,6 +196,7 @@ def upload_local_video(direction: str = Form("en-zh"), file: UploadFile = File(.
     if direction not in LOCAL_UPLOAD_DIRECTIONS:
         raise HTTPException(status_code=422, detail="Unsupported local video direction.")
 
+    _ensure_runtime_ready()
     original_name = Path(file.filename or "").name.strip()
     stored_name = _clean_upload_filename(original_name)
     task_id = str(uuid.uuid4())
@@ -264,6 +274,7 @@ def rerun_task(task_id: str) -> dict:
     if task["status"] == "running":
         raise HTTPException(status_code=409, detail="Cannot rerun a running task.")
 
+    _ensure_runtime_ready()
     url = task["url"]
     _purge_task(task)
     new_id = database.create_task(url, task_id=task_id)
@@ -278,6 +289,7 @@ def resume_task(task_id: str) -> dict:
         raise HTTPException(status_code=404, detail="Task not found.")
     if task["status"] != "failed":
         raise HTTPException(status_code=409, detail="Only failed tasks can be resumed.")
+    _ensure_runtime_ready()
     database.reset_failed_for_resume(task_id)
     worker.enqueue(task_id)
     return database.get_task(task_id)

--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 from . import database
 from .config import WORKFOLDER
+from .runtime_checks import validate_runtime_device
 from .sources import detect_source
 from .stages import STAGES
 from .youtube import is_local_upload_url
@@ -74,6 +75,7 @@ class PipelineRunner:
         self.log("Task started")
 
         try:
+            validate_runtime_device()
             for stage in STAGES:
                 self._run_stage(stage.name)
             database.update_task(

--- a/backend/app/runtime_checks.py
+++ b/backend/app/runtime_checks.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from .config import device
+
+
+CUDA_INSTALL_HINT = (
+    "Install a CUDA-enabled PyTorch build before requirements.txt, for example: "
+    "pip install -r requirements-pytorch-cu128.txt. Then verify with: "
+    "python -c \"import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())\""
+)
+
+
+def _wants_cuda(selected_device: str) -> bool:
+    normalized = selected_device.strip().lower()
+    return normalized == "cuda" or normalized.startswith("cuda:")
+
+
+def _cuda_device_index(selected_device: str) -> int | None:
+    normalized = selected_device.strip().lower()
+    if not normalized.startswith("cuda:"):
+        return None
+    suffix = normalized.split(":", 1)[1]
+    if not suffix.isdigit():
+        raise RuntimeError(f"DEVICE={selected_device} is not a valid CUDA device name.")
+    return int(suffix)
+
+
+def _load_torch():
+    import torch
+
+    return torch
+
+
+def validate_runtime_device() -> None:
+    selected_device = device().strip()
+    if not _wants_cuda(selected_device):
+        return
+
+    requested_index = _cuda_device_index(selected_device)
+    try:
+        torch = _load_torch()
+    except ImportError as exc:
+        raise RuntimeError(
+            f"DEVICE={selected_device} is configured, but PyTorch is not installed. "
+            f"{CUDA_INSTALL_HINT}"
+        ) from exc
+
+    if not torch.cuda.is_available():
+        torch_version = getattr(torch, "__version__", "unknown")
+        cuda_version = getattr(getattr(torch, "version", None), "cuda", None) or "None"
+        raise RuntimeError(
+            f"DEVICE={selected_device} is configured, but CUDA is not available in the current "
+            f"PyTorch runtime. torch={torch_version}, torch.version.cuda={cuda_version}. "
+            f"{CUDA_INSTALL_HINT}"
+        )
+
+    if requested_index is not None and requested_index >= torch.cuda.device_count():
+        raise RuntimeError(
+            f"DEVICE={selected_device} is configured, but only {torch.cuda.device_count()} CUDA "
+            "device(s) are visible to PyTorch."
+        )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(autouse=True)
+def default_test_device(monkeypatch):
+    monkeypatch.setenv("DEVICE", "cpu")
 

--- a/backend/tests/test_runtime_checks.py
+++ b/backend/tests/test_runtime_checks.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from backend.app import runtime_checks
+
+
+def fake_torch(cuda_available: bool, cuda_version: str | None = None, device_count: int = 1):
+    return types.SimpleNamespace(
+        __version__="2.11.0",
+        version=types.SimpleNamespace(cuda=cuda_version),
+        cuda=types.SimpleNamespace(
+            is_available=lambda: cuda_available,
+            device_count=lambda: device_count,
+        ),
+    )
+
+
+def test_validate_runtime_device_skips_cpu(monkeypatch):
+    monkeypatch.setattr(runtime_checks, "device", lambda: "cpu")
+    monkeypatch.setattr(
+        runtime_checks,
+        "_load_torch",
+        lambda: (_ for _ in ()).throw(AssertionError("torch should not be loaded")),
+    )
+
+    runtime_checks.validate_runtime_device()
+
+
+def test_validate_runtime_device_accepts_cuda(monkeypatch):
+    monkeypatch.setattr(runtime_checks, "device", lambda: "cuda:0")
+    monkeypatch.setattr(runtime_checks, "_load_torch", lambda: fake_torch(True, "12.8"))
+
+    runtime_checks.validate_runtime_device()
+
+
+def test_validate_runtime_device_rejects_unavailable_cuda(monkeypatch):
+    monkeypatch.setattr(runtime_checks, "device", lambda: "cuda")
+    monkeypatch.setattr(runtime_checks, "_load_torch", lambda: fake_torch(False, None))
+
+    with pytest.raises(RuntimeError, match="CUDA is not available") as exc:
+        runtime_checks.validate_runtime_device()
+
+    assert "requirements-pytorch-cu128.txt" in str(exc.value)
+
+
+def test_validate_runtime_device_rejects_missing_cuda_index(monkeypatch):
+    monkeypatch.setattr(runtime_checks, "device", lambda: "cuda:1")
+    monkeypatch.setattr(runtime_checks, "_load_torch", lambda: fake_torch(True, "12.8", device_count=1))
+
+    with pytest.raises(RuntimeError, match="only 1 CUDA"):
+        runtime_checks.validate_runtime_device()

--- a/backend/tests/test_settings_and_api.py
+++ b/backend/tests/test_settings_and_api.py
@@ -527,6 +527,19 @@ def test_create_task_rejects_local_upload_url(monkeypatch, tmp_path):
     assert response.status_code == 422
 
 
+def test_create_task_rejects_unavailable_cuda_runtime(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        main,
+        "validate_runtime_device",
+        lambda: (_ for _ in ()).throw(RuntimeError("DEVICE=cuda is not available")),
+    )
+    client = TestClient(main.app)
+    response = client.post("/api/tasks", json={"url": "https://www.youtube.com/watch?v=okvideoxxxx"})
+    assert response.status_code == 409
+    assert response.json()["detail"] == "DEVICE=cuda is not available"
+
+
 def test_delete_local_video_removes_upload(monkeypatch, tmp_path):
     configure_tmp_runtime(monkeypatch, tmp_path)
     client = TestClient(main.app)

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,6 +1,0 @@
-# CUDA-enabled PyTorch packages.
-#
-# Install this before requirements.txt when you want GPU inference.
-# For CPU inference, skip this file.
-torch
-torchaudio

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,0 +1,6 @@
+# CUDA-enabled PyTorch packages.
+#
+# Install this before requirements.txt when you want GPU inference.
+# For CPU inference, skip this file.
+torch
+torchaudio

--- a/requirements-pytorch-cu128.txt
+++ b/requirements-pytorch-cu128.txt
@@ -1,0 +1,7 @@
+# CUDA 12.8 PyTorch wheels for NVIDIA GPU inference.
+#
+# Install this before requirements.txt. For CPU or macOS inference, skip this file.
+# Use https://pytorch.org/get-started/locally/ if your driver needs a different build.
+--index-url https://download.pytorch.org/whl/cu128
+torch
+torchaudio


### PR DESCRIPTION
## 变更内容

本 PR 补充了 CUDA 版 PyTorch 的可选安装步骤：

- 新增 `requirements-cuda.txt`，用于安装支持 CUDA 的 `torch` 和 `torchaudio`
- 在中英文 README 的 Python 依赖安装流程中，加入先安装 `requirements-cuda.txt` 的步骤
- 说明 CPU 推理用户可以跳过该步骤
- 说明如需指定 CUDA 版本，可前往 PyTorch 官方网站获取对应安装命令

## 背景

当前 `requirements.txt` 没有显式指定 CUDA 版 PyTorch。用户直接通过普通 PyPI 镜像安装依赖时，可能安装到 CPU 版 PyTorch，导致本地模型无法使用 NVIDIA GPU 推理。

本次改动提供一个轻量的安装入口，方便需要 GPU 推理的用户优先安装 CUDA 版 PyTorch，同时不影响只使用 CPU 推理的用户。