### PR TITLE
perf(voxcpm): reuse fallback prompt cache for short references

### DIFF
--- a/backend/app/adapters/voxcpm.py
+++ b/backend/app/adapters/voxcpm.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Callable
 
@@ -11,6 +12,14 @@ from pydub import AudioSegment
 from ..config import MODEL_CACHE_DIR
 
 _MODEL = None
+
+_PROMPT_CACHE_GENERATION_DEFAULTS = {
+    "min_len": 2,
+    "max_len": 4096,
+    "retry_badcase": True,
+    "retry_badcase_max_times": 3,
+    "retry_badcase_ratio_threshold": 6.0,
+}
 
 
 def _model_path() -> Path:
@@ -48,6 +57,14 @@ def _fallback_reference(vocals_dir: Path, min_ms: int) -> Path:
     return files[0]
 
 
+def _tts_text(item: dict) -> str:
+    text = item.get("dst") or item.get("zh", "")
+    if not isinstance(text, str) or not text.strip():
+        raise ValueError("target text must be a non-empty string")
+    text = text.replace("\n", " ")
+    return re.sub(r"\s+", " ", text)
+
+
 def generate_tts(
     translation_file: Path,
     vocals_dir: Path,
@@ -76,22 +93,24 @@ def generate_tts(
         output_file = output_dir / f"{index:04d}.wav"
         if not output_file.exists():
             reference = vocals_dir / f"{index:04d}.wav"
+            text = _tts_text(item)
             if not reference.exists() or len(AudioSegment.from_file(reference)) < min_reference_ms:
                 if fallback_cache is None:
                     fallback_cache = model.tts_model.build_prompt_cache(
                         reference_wav_path=str(fallback)
                     )
                 result = model.tts_model.generate_with_prompt_cache(
-                    target_text=item.get("dst") or item.get("zh", ""),
+                    target_text=text,
                     prompt_cache=fallback_cache,
                     cfg_value=cfg_value,
                     inference_timesteps=inference_timesteps,
+                    **_PROMPT_CACHE_GENERATION_DEFAULTS,
                 )
                 wav_tensor, _, _ = result
                 wav = wav_tensor.squeeze(0).cpu().numpy()
             else:
                 wav = model.generate(
-                    text=item.get("dst") or item.get("zh", ""),
+                    text=text,
                     reference_wav_path=str(reference),
                     cfg_value=cfg_value,
                     inference_timesteps=inference_timesteps,

--- a/backend/app/adapters/voxcpm.py
+++ b/backend/app/adapters/voxcpm.py
@@ -67,19 +67,35 @@ def generate_tts(
     model = _load_model()
     min_reference_ms = int(os.getenv("VOXCPM_MIN_REFERENCE_MS", "1200"))
     fallback = _fallback_reference(vocals_dir, min_reference_ms)
+    cfg_value = float(os.getenv("VOXCPM_CFG_VALUE", "2.0"))
+    inference_timesteps = int(os.getenv("VOXCPM_INFERENCE_TIMESTEPS", "10"))
+
+    fallback_cache = None
 
     for index, item in enumerate(items, start=1):
         output_file = output_dir / f"{index:04d}.wav"
         if not output_file.exists():
             reference = vocals_dir / f"{index:04d}.wav"
             if not reference.exists() or len(AudioSegment.from_file(reference)) < min_reference_ms:
-                reference = fallback
-            wav = model.generate(
-                text=item.get("dst") or item.get("zh", ""),
-                reference_wav_path=str(reference),
-                cfg_value=float(os.getenv("VOXCPM_CFG_VALUE", "2.0")),
-                inference_timesteps=int(os.getenv("VOXCPM_INFERENCE_TIMESTEPS", "10")),
-            )
+                if fallback_cache is None:
+                    fallback_cache = model.tts_model.build_prompt_cache(
+                        reference_wav_path=str(fallback)
+                    )
+                result = model.tts_model.generate_with_prompt_cache(
+                    target_text=item.get("dst") or item.get("zh", ""),
+                    prompt_cache=fallback_cache,
+                    cfg_value=cfg_value,
+                    inference_timesteps=inference_timesteps,
+                )
+                wav_tensor, _, _ = result
+                wav = wav_tensor.squeeze(0).cpu().numpy()
+            else:
+                wav = model.generate(
+                    text=item.get("dst") or item.get("zh", ""),
+                    reference_wav_path=str(reference),
+                    cfg_value=cfg_value,
+                    inference_timesteps=inference_timesteps,
+                )
             sf.write(output_file, wav, model.tts_model.sample_rate)
         if progress_callback:
             progress = round(index / total * 100)

--- a/backend/tests/test_voxcpm.py
+++ b/backend/tests/test_voxcpm.py
@@ -26,6 +26,15 @@ def _write_translation_json(path: Path, items: list[dict]) -> Path:
     return path
 
 
+_CACHE_GENERATION_DEFAULTS = {
+    "min_len": 2,
+    "max_len": 4096,
+    "retry_badcase": True,
+    "retry_badcase_max_times": 3,
+    "retry_badcase_ratio_threshold": 6.0,
+}
+
+
 @patch.object(voxcpm_mod, "_fallback_reference")
 @patch.object(voxcpm_mod, "_load_model")
 def test_fallback_cache_built_once_and_reused(mock_load, mock_fallback, tmp_path):
@@ -81,18 +90,21 @@ def test_fallback_cache_built_once_and_reused(mock_load, mock_fallback, tmp_path
                 prompt_cache=mock_cache,
                 cfg_value=2.0,
                 inference_timesteps=10,
+                **_CACHE_GENERATION_DEFAULTS,
             ),
             call(
                 target_text="Another fallback sentence.",
                 prompt_cache=mock_cache,
                 cfg_value=2.0,
                 inference_timesteps=10,
+                **_CACHE_GENERATION_DEFAULTS,
             ),
             call(
                 target_text="Third fallback.",
                 prompt_cache=mock_cache,
                 cfg_value=2.0,
                 inference_timesteps=10,
+                **_CACHE_GENERATION_DEFAULTS,
             ),
         ]
     )
@@ -151,6 +163,8 @@ def test_skips_existing_tts_files(mock_load, mock_fallback, tmp_path):
     assert mock_tts_model.generate_with_prompt_cache.call_count == 1
     call_kwargs = mock_tts_model.generate_with_prompt_cache.call_args.kwargs
     assert call_kwargs["target_text"] == "Second sentence."
+    for key, value in _CACHE_GENERATION_DEFAULTS.items():
+        assert call_kwargs[key] == value
 
 
 @patch.object(voxcpm_mod, "_fallback_reference")
@@ -245,3 +259,42 @@ def test_model_generate_used_for_own_reference(mock_load, mock_fallback, tmp_pat
     # generate_with_prompt_cache is not used (both have their own ref)
     mock_tts_model.generate_with_prompt_cache.assert_not_called()
     assert mock_model.generate.call_count == 2
+
+
+@patch.object(voxcpm_mod, "_fallback_reference")
+@patch.object(voxcpm_mod, "_load_model")
+def test_fallback_cache_preserves_wrapper_generation_behavior(mock_load, mock_fallback, tmp_path):
+    """Cached fallback generation keeps VoxCPM.generate defaults and text cleanup."""
+    session = tmp_path / "session"
+    vocals_dir = session / "segments" / "vocals"
+    ref_0001 = _make_synthetic_wav(vocals_dir / "0001.wav", duration_ms=600)
+    mock_fallback.return_value = ref_0001
+
+    translation = _write_translation_json(
+        session / "metadata" / "translation.en.json",
+        [{"dst": "Hello\n   cached    world."}],
+    )
+
+    mock_tts_model = MagicMock()
+    mock_tts_model.sample_rate = 16000
+    mock_cache = {"ref_audio_feat": MagicMock(), "mode": "reference"}
+    mock_tts_model.build_prompt_cache.return_value = mock_cache
+
+    fake_wav_tensor = MagicMock()
+    fake_wav_tensor.squeeze.return_value.cpu.return_value.numpy.return_value = np.zeros(1600, dtype=np.float32)
+    mock_tts_model.generate_with_prompt_cache.return_value = (fake_wav_tensor, MagicMock(), MagicMock())
+
+    mock_model = MagicMock()
+    mock_model.tts_model = mock_tts_model
+    mock_load.return_value = mock_model
+
+    voxcpm_mod.generate_tts(translation, vocals_dir, session)
+
+    mock_tts_model.generate_with_prompt_cache.assert_called_once_with(
+        target_text="Hello cached world.",
+        prompt_cache=mock_cache,
+        cfg_value=2.0,
+        inference_timesteps=10,
+        **_CACHE_GENERATION_DEFAULTS,
+    )
+    mock_model.generate.assert_not_called()

--- a/backend/tests/test_voxcpm.py
+++ b/backend/tests/test_voxcpm.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+import soundfile as sf
+
+from backend.app.adapters import voxcpm as voxcpm_mod
+
+
+def _make_synthetic_wav(path: Path, duration_ms: int = 1500) -> Path:
+    """Create a minimal WAV file for testing."""
+    rate = 16000
+    samples = int(rate * duration_ms / 1000)
+    wav = np.sin(2 * np.pi * 440 * np.linspace(0, duration_ms / 1000, samples)).astype(np.float32)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sf.write(path, wav, rate)
+    return path
+
+
+def _write_translation_json(path: Path, items: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"translation": items}), encoding="utf-8")
+    return path
+
+
+@patch.object(voxcpm_mod, "_fallback_reference")
+@patch.object(voxcpm_mod, "_load_model")
+def test_fallback_cache_built_once_and_reused(mock_load, mock_fallback, tmp_path):
+    """Prompt cache is built exactly once for the fallback reference."""
+    session = tmp_path / "session"
+    vocals_dir = session / "segments" / "vocals"
+    ref_0001 = _make_synthetic_wav(vocals_dir / "0001.wav", duration_ms=600)
+    ref_0002 = _make_synthetic_wav(vocals_dir / "0002.wav", duration_ms=600)
+    ref_0003 = _make_synthetic_wav(vocals_dir / "0003.wav", duration_ms=300)
+    ref_0004 = _make_synthetic_wav(vocals_dir / "0004.wav", duration_ms=2000)
+
+    fallback_path = ref_0004
+    mock_fallback.return_value = fallback_path
+
+    translation = _write_translation_json(
+        session / "metadata" / "translation.en.json",
+        [
+            {"dst": "Short segment requiring fallback."},
+            {"dst": "Another fallback sentence."},
+            {"dst": "Third fallback."},
+            {"dst": "Own reference sentence."},
+        ],
+    )
+
+    mock_tts_model = MagicMock()
+    mock_tts_model.sample_rate = 16000
+    mock_cache = {"ref_audio_feat": MagicMock(), "mode": "reference"}
+
+    mock_tts_model.build_prompt_cache.return_value = mock_cache
+
+    fake_wav_tensor = MagicMock()
+    fake_wav_tensor.squeeze.return_value.cpu.return_value.numpy.return_value = np.zeros(1600, dtype=np.float32)
+    mock_tts_model.generate_with_prompt_cache.return_value = (fake_wav_tensor, MagicMock(), MagicMock())
+
+    mock_model = MagicMock()
+    mock_model.tts_model = mock_tts_model
+    mock_model.generate.return_value = np.zeros(1600, dtype=np.float32)
+    mock_load.return_value = mock_model
+
+    voxcpm_mod.generate_tts(translation, vocals_dir, session)
+
+    # build_prompt_cache called exactly once with fallback path
+    mock_tts_model.build_prompt_cache.assert_called_once_with(
+        reference_wav_path=str(fallback_path)
+    )
+
+    # generate_with_prompt_cache called for the 3 short segments
+    assert mock_tts_model.generate_with_prompt_cache.call_count == 3
+    mock_tts_model.generate_with_prompt_cache.assert_has_calls(
+        [
+            call(
+                target_text="Short segment requiring fallback.",
+                prompt_cache=mock_cache,
+                cfg_value=2.0,
+                inference_timesteps=10,
+            ),
+            call(
+                target_text="Another fallback sentence.",
+                prompt_cache=mock_cache,
+                cfg_value=2.0,
+                inference_timesteps=10,
+            ),
+            call(
+                target_text="Third fallback.",
+                prompt_cache=mock_cache,
+                cfg_value=2.0,
+                inference_timesteps=10,
+            ),
+        ]
+    )
+
+    # model.generate called for the sentence with its own reference
+    assert mock_model.generate.call_count == 1
+    mock_model.generate.assert_called_once_with(
+        text="Own reference sentence.",
+        reference_wav_path=str(ref_0004),
+        cfg_value=2.0,
+        inference_timesteps=10,
+    )
+
+
+@patch.object(voxcpm_mod, "_fallback_reference")
+@patch.object(voxcpm_mod, "_load_model")
+def test_skips_existing_tts_files(mock_load, mock_fallback, tmp_path):
+    """Pre-existing TTS output files are not regenerated."""
+    session = tmp_path / "session"
+    vocals_dir = session / "segments" / "vocals"
+    tts_dir = session / "segments" / "tts"
+    tts_dir.mkdir(parents=True)
+
+    ref_0001 = _make_synthetic_wav(vocals_dir / "0001.wav", duration_ms=600)
+    ref_0002 = _make_synthetic_wav(vocals_dir / "0002.wav", duration_ms=600)
+    fallback_path = ref_0002
+    mock_fallback.return_value = fallback_path
+
+    translation = _write_translation_json(
+        session / "metadata" / "translation.en.json",
+        [
+            {"dst": "First sentence."},
+            {"dst": "Second sentence."},
+        ],
+    )
+
+    # Pre-create output file for sentence 0001
+    sf.write(tts_dir / "0001.wav", np.zeros(1600, dtype=np.float32), 16000)
+
+    mock_tts_model = MagicMock()
+    mock_tts_model.sample_rate = 16000
+    mock_cache = {"ref_audio_feat": MagicMock(), "mode": "reference"}
+    mock_tts_model.build_prompt_cache.return_value = mock_cache
+
+    fake_wav_tensor = MagicMock()
+    fake_wav_tensor.squeeze.return_value.cpu.return_value.numpy.return_value = np.zeros(1600, dtype=np.float32)
+    mock_tts_model.generate_with_prompt_cache.return_value = (fake_wav_tensor, MagicMock(), MagicMock())
+
+    mock_model = MagicMock()
+    mock_model.tts_model = mock_tts_model
+    mock_load.return_value = mock_model
+
+    voxcpm_mod.generate_tts(translation, vocals_dir, session)
+
+    # Should only generate for sentence 0002 (0001 exists)
+    assert mock_tts_model.generate_with_prompt_cache.call_count == 1
+    call_kwargs = mock_tts_model.generate_with_prompt_cache.call_args.kwargs
+    assert call_kwargs["target_text"] == "Second sentence."
+
+
+@patch.object(voxcpm_mod, "_fallback_reference")
+@patch.object(voxcpm_mod, "_load_model")
+def test_empty_translation_skips_tts(mock_load, mock_fallback, tmp_path):
+    """Empty translation items list returns early without calling the model."""
+    session = tmp_path / "session"
+    translation = _write_translation_json(
+        session / "metadata" / "translation.en.json",
+        [],
+    )
+
+    mock_model = MagicMock()
+    mock_load.return_value = mock_model
+
+    result = voxcpm_mod.generate_tts(translation, tmp_path, session)
+    assert result == session / "segments" / "tts"
+    mock_model.tts_model.build_prompt_cache.assert_not_called()
+
+
+@patch.object(voxcpm_mod, "_fallback_reference")
+@patch.object(voxcpm_mod, "_load_model")
+def test_calls_progress_callback(mock_load, mock_fallback, tmp_path):
+    """Progress callback is invoked for each item and reports 100 at the end."""
+    session = tmp_path / "session"
+    vocals_dir = session / "segments" / "vocals"
+    ref_0001 = _make_synthetic_wav(vocals_dir / "0001.wav", duration_ms=600)
+    ref_0002 = _make_synthetic_wav(vocals_dir / "0002.wav", duration_ms=600)
+
+    fallback_path = ref_0002
+    mock_fallback.return_value = fallback_path
+
+    translation = _write_translation_json(
+        session / "metadata" / "translation.en.json",
+        [{"dst": "A"}, {"dst": "B"}, {"dst": "C"}],
+    )
+
+    mock_tts_model = MagicMock()
+    mock_tts_model.sample_rate = 16000
+    mock_cache = {"ref_audio_feat": MagicMock(), "mode": "reference"}
+    mock_tts_model.build_prompt_cache.return_value = mock_cache
+
+    fake_wav_tensor = MagicMock()
+    fake_wav_tensor.squeeze.return_value.cpu.return_value.numpy.return_value = np.zeros(1600, dtype=np.float32)
+    mock_tts_model.generate_with_prompt_cache.return_value = (fake_wav_tensor, MagicMock(), MagicMock())
+
+    mock_model = MagicMock()
+    mock_model.tts_model = mock_tts_model
+    mock_load.return_value = mock_model
+
+    cb = MagicMock()
+    voxcpm_mod.generate_tts(translation, vocals_dir, session, progress_callback=cb)
+
+    # progress called for each item
+    progress_calls = [c for c in cb.call_args_list if c.args[1].startswith("Prepared")]
+    assert len(progress_calls) == 3
+    assert progress_calls[0].args[0] == 33
+    assert progress_calls[1].args[0] == 67
+    assert progress_calls[2].args[0] == 100
+
+
+@patch.object(voxcpm_mod, "_fallback_reference")
+@patch.object(voxcpm_mod, "_load_model")
+def test_model_generate_used_for_own_reference(mock_load, mock_fallback, tmp_path):
+    """Sentences with their own long-enough reference still use model.generate."""
+    session = tmp_path / "session"
+    vocals_dir = session / "segments" / "vocals"
+    ref_0001 = _make_synthetic_wav(vocals_dir / "0001.wav", duration_ms=2000)
+    ref_0002 = _make_synthetic_wav(vocals_dir / "0002.wav", duration_ms=2000)
+
+    mock_fallback.return_value = ref_0001
+
+    translation = _write_translation_json(
+        session / "metadata" / "translation.en.json",
+        [{"dst": "Own ref."}, {"dst": "Also own ref."}],
+    )
+
+    mock_tts_model = MagicMock()
+    mock_tts_model.sample_rate = 16000
+    mock_cache = {"ref_audio_feat": MagicMock(), "mode": "reference"}
+    mock_tts_model.build_prompt_cache.return_value = mock_cache
+
+    mock_model = MagicMock()
+    mock_model.tts_model = mock_tts_model
+    mock_model.generate.return_value = np.zeros(1600, dtype=np.float32)
+    mock_load.return_value = mock_model
+
+    voxcpm_mod.generate_tts(translation, vocals_dir, session)
+
+    # fallback_cache is not built because no sentence falls back
+    mock_tts_model.build_prompt_cache.assert_not_called()
+    # generate_with_prompt_cache is not used (both have their own ref)
+    mock_tts_model.generate_with_prompt_cache.assert_not_called()
+    assert mock_model.generate.call_count == 2


### PR DESCRIPTION
Closes #84

## Summary

Reuses the VoxCPM2 prompt cache across fallback TTS sentences to avoid redundant reference-audio encoding while preserving the behavior of the public `VoxCPM.generate()` wrapper.

The fallback reference prompt cache is built once and reused for every short/missing reference segment. Sentences with their own long-enough reference still use `model.generate()` unchanged.

## Changes

### `backend/app/adapters/voxcpm.py`

- Extract `cfg_value` and `inference_timesteps` from env once, outside the generation loop.
- Build the fallback reference prompt cache once via `model.tts_model.build_prompt_cache()`.
- Use `model.tts_model.generate_with_prompt_cache()` for fallback sentences.
- Preserve wrapper-equivalent generation behavior on the cached fallback path:
  - text cleanup for newlines and repeated whitespace
  - `min_len=2`
  - `max_len=4096`
  - `retry_badcase=True`
  - `retry_badcase_max_times=3`
  - `retry_badcase_ratio_threshold=6.0`

### `backend/tests/test_voxcpm.py`

- Adds unit coverage for prompt-cache reuse.
- Verifies existing TTS files are skipped.
- Verifies empty translation lists return early.
- Verifies progress callbacks.
- Verifies own-reference segments still use `model.generate()`.
- Adds regression coverage that cached fallback generation keeps wrapper-equivalent defaults and text cleanup.

## Version note

Current reviewed runtime has `voxcpm==2.0.2`; PyPI latest is `2.0.3`. Both versions keep the same relevant default mismatch: `VoxCPM.generate()` defaults to `max_len=4096` and `retry_badcase=True`, while the lower-level cached generation API defaults to `max_len=2000` and `retry_badcase=False`. This PR fixes that in application code and does not include a dependency bump.

## Test results

- `pytest backend/tests/test_voxcpm.py -q`: 6 passed
- `pytest backend/tests/test_pipeline.py backend/tests/test_settings_and_api.py backend/tests/test_devices.py -q`: 58 passed
- `pytest backend/tests -q`: 126 passed
- `git diff --check origin/main...HEAD`: passed
- `git diff --check`: passed
