### PR TITLE
修复 OpenAI 密钥跨地址复用风险

### DIFF
--- a/backend/app/adapters/openai_client.py
+++ b/backend/app/adapters/openai_client.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 
 def normalize_openai_base_url(base_url: str) -> str:
     url = base_url.strip().rstrip("/")
@@ -9,3 +11,17 @@ def normalize_openai_base_url(base_url: str) -> str:
             url = url[: -len(suffix)].rstrip("/")
             lowered = url.lower()
     return url or "https://api.openai.com/v1"
+
+
+def validate_openai_base_url(base_url: str) -> str:
+    url = normalize_openai_base_url(base_url)
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("OpenAI base URL must be an absolute HTTP(S) URL with a host.")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("OpenAI base URL must not contain credentials, a query, or a fragment.")
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("OpenAI base URL contains an invalid port.") from exc
+    return url

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -436,12 +436,27 @@ def get_openai_settings() -> dict[str, str]:
     from .adapters.openai_client import normalize_openai_base_url
 
     defaults = openai_defaults()
+    keys = {
+        "base_url": "openai.base_url",
+        "api_key": "openai.api_key",
+        "model": "openai.model",
+        "translate_concurrency": "openai.translate_concurrency",
+    }
+    placeholders = ", ".join("?" for _ in keys)
+    with connect() as conn:
+        rows = conn.execute(
+            f"SELECT key, value FROM settings WHERE key IN ({placeholders})",
+            tuple(keys.values()),
+        ).fetchall()
+    saved = {row["key"]: row["value"] for row in rows}
     return {
-        "base_url": normalize_openai_base_url(get_setting("openai.base_url", defaults["base_url"])),
-        "api_key": get_setting("openai.api_key", defaults["api_key"]),
-        "model": get_setting("openai.model", defaults["model"]),
-        "translate_concurrency": get_setting(
-            "openai.translate_concurrency", defaults["translate_concurrency"]
+        "base_url": normalize_openai_base_url(
+            saved.get(keys["base_url"], defaults["base_url"])
+        ),
+        "api_key": saved.get(keys["api_key"], defaults["api_key"]),
+        "model": saved.get(keys["model"], defaults["model"]),
+        "translate_concurrency": saved.get(
+            keys["translate_concurrency"], defaults["translate_concurrency"]
         ),
     }
 
@@ -454,17 +469,53 @@ def save_openai_settings(
     *,
     clear_api_key: bool = False,
 ) -> None:
-    from .adapters.openai_client import normalize_openai_base_url
+    from .adapters.openai_client import validate_openai_base_url
 
-    set_setting("openai.base_url", normalize_openai_base_url(base_url))
+    validated_base_url = validate_openai_base_url(base_url)
+    defaults = openai_defaults()
     cleaned_api_key = api_key.strip()
-    if clear_api_key:
-        set_setting("openai.api_key", "")
-    elif cleaned_api_key and set(cleaned_api_key) != {"*"}:
-        set_setting("openai.api_key", cleaned_api_key)
-    set_setting("openai.model", model.strip())
-    if translate_concurrency.strip():
-        set_setting("openai.translate_concurrency", translate_concurrency.strip())
+    has_explicit_api_key = bool(cleaned_api_key) and set(cleaned_api_key) != {"*"}
+    updated_at = now_iso()
+
+    with connect() as conn:
+        conn.execute("BEGIN IMMEDIATE")
+
+        def current_value(key: str, default: str) -> str:
+            row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+            return row["value"] if row else default
+
+        current_base_url = validate_openai_base_url(
+            current_value("openai.base_url", defaults["base_url"])
+        )
+        current_api_key = current_value("openai.api_key", defaults["api_key"])
+        if (
+            validated_base_url != current_base_url
+            and current_api_key
+            and not has_explicit_api_key
+            and not clear_api_key
+        ):
+            raise ValueError("A new API key is required when changing the OpenAI base URL.")
+
+        updates = {
+            "openai.base_url": validated_base_url,
+            "openai.model": model.strip(),
+        }
+        if clear_api_key:
+            updates["openai.api_key"] = ""
+        elif has_explicit_api_key:
+            updates["openai.api_key"] = cleaned_api_key
+        if translate_concurrency.strip():
+            updates["openai.translate_concurrency"] = translate_concurrency.strip()
+
+        conn.executemany(
+            """
+            INSERT INTO settings (key, value, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(key) DO UPDATE
+            SET value = excluded.value, updated_at = excluded.updated_at
+            """,
+            [(key, value, updated_at) for key, value in updates.items()],
+        )
 
 
 def get_ytdlp_settings() -> dict[str, str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from . import database, worker
 from .adapters.local_subtitles import parse_srt, uploaded_subtitle_dir
 from .adapters.local_video import remove_upload, uploaded_video_dir
+from .adapters.openai_client import validate_openai_base_url
 from .adapters.openai_translate import list_models as list_openai_models
 from .config import WORKFOLDER, YOUTUBE_COOKIE_PATH, ensure_runtime_dirs
 from .pipeline import run_task
@@ -490,27 +491,49 @@ def get_openai_settings() -> dict:
 
 @app.post("/api/settings/openai")
 def save_openai_settings(payload: OpenAISettingsUpdate) -> dict:
-    database.save_openai_settings(
-        payload.base_url,
-        payload.api_key,
-        payload.model,
-        normalize_translate_concurrency(payload.translate_concurrency),
-        clear_api_key=payload.clear_api_key,
-    )
+    try:
+        database.save_openai_settings(
+            payload.base_url,
+            payload.api_key,
+            payload.model,
+            normalize_translate_concurrency(payload.translate_concurrency),
+            clear_api_key=payload.clear_api_key,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return get_openai_settings()
 
 
 @app.post("/api/settings/openai/models")
 def get_openai_models(payload: OpenAIModelsRequest) -> dict:
     settings = database.get_openai_settings()
-    base_url = payload.base_url.strip() or settings["base_url"]
-    api_key = payload.api_key.strip() or settings["api_key"]
+    try:
+        saved_base_url = validate_openai_base_url(settings["base_url"])
+        requested_base_url = payload.base_url.strip()
+        base_url = (
+            validate_openai_base_url(requested_base_url)
+            if requested_base_url
+            else saved_base_url
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    requested_api_key = payload.api_key.strip()
+    if requested_base_url and base_url != saved_base_url and not requested_api_key:
+        raise HTTPException(
+            status_code=422,
+            detail="An API key is required when testing a different OpenAI base URL.",
+        )
+    api_key = requested_api_key or settings["api_key"]
+    if not api_key:
+        raise HTTPException(status_code=400, detail="OpenAI API key is not configured.")
     try:
         models = list_openai_models(base_url=base_url, api_key=api_key)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        raise HTTPException(status_code=502, detail=f"Failed to fetch models: {exc}") from exc
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to fetch models from the OpenAI-compatible API.",
+        ) from exc
     return {"models": models}
 
 

--- a/backend/tests/test_openai_client.py
+++ b/backend/tests/test_openai_client.py
@@ -1,5 +1,10 @@
+import pytest
+
 from backend.app.adapters import openai_translate
-from backend.app.adapters.openai_client import normalize_openai_base_url
+from backend.app.adapters.openai_client import (
+    normalize_openai_base_url,
+    validate_openai_base_url,
+)
 
 
 def test_normalize_openai_base_url_strips_chat_completions_suffix():
@@ -11,6 +16,33 @@ def test_normalize_openai_base_url_strips_chat_completions_suffix():
 
 def test_normalize_openai_base_url_keeps_standard_v1_root():
     assert normalize_openai_base_url("https://api.openai.com/v1/") == "https://api.openai.com/v1"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("https://api.example.com/v1/", "https://api.example.com/v1"),
+        ("http://localhost:11434/v1/chat/completions", "http://localhost:11434/v1"),
+    ],
+)
+def test_validate_openai_base_url_accepts_absolute_http_urls(value: str, expected: str):
+    assert validate_openai_base_url(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ftp://api.example.com/v1",
+        "api.example.com/v1",
+        "https:///v1",
+        "https://user:password@api.example.com/v1",
+        "https://api.example.com/v1?key=value",
+        "https://api.example.com:99999/v1",
+    ],
+)
+def test_validate_openai_base_url_rejects_unsafe_or_invalid_urls(value: str):
+    with pytest.raises(ValueError):
+        validate_openai_base_url(value)
 
 
 def test_openai_client_initializes_with_socks_proxy_environment(monkeypatch):

--- a/backend/tests/test_settings_and_api.py
+++ b/backend/tests/test_settings_and_api.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import sqlite3
+import threading
 
 import pytest
 from fastapi.testclient import TestClient
@@ -502,6 +504,288 @@ def test_openai_models_can_use_saved_key(monkeypatch, tmp_path):
     assert captured == {"base_url": "https://saved.example/v1", "api_key": "sk-saved"}
 
 
+def test_openai_models_reject_changed_base_without_explicit_key(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    database.save_openai_settings("https://saved.example/v1", "sk-saved", "saved-model")
+    called = False
+
+    def fake_list_models(*, base_url: str, api_key: str) -> list[str]:
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(main, "list_openai_models", fake_list_models)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/settings/openai/models",
+        json={"base_url": "https://other.example/v1", "api_key": ""},
+    )
+
+    assert response.status_code == 422
+    assert called is False
+    assert "sk-saved" not in response.text
+
+
+def test_openai_models_reject_invalid_base_url(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    called = False
+
+    def fake_list_models(*, base_url: str, api_key: str) -> list[str]:
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(main, "list_openai_models", fake_list_models)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/settings/openai/models",
+        json={"base_url": "ftp://api.example.com/v1", "api_key": "sk-temporary"},
+    )
+
+    assert response.status_code == 422
+    assert called is False
+    assert "sk-temporary" not in response.text
+
+
+def test_openai_models_allow_equivalent_saved_base_without_key(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    database.save_openai_settings("https://saved.example/v1", "sk-saved", "saved-model")
+    captured = {}
+
+    def fake_list_models(*, base_url: str, api_key: str) -> list[str]:
+        captured.update(base_url=base_url, api_key=api_key)
+        return ["saved-model"]
+
+    monkeypatch.setattr(main, "list_openai_models", fake_list_models)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/settings/openai/models",
+        json={"base_url": "https://saved.example/v1/chat/completions", "api_key": ""},
+    )
+
+    assert response.status_code == 200
+    assert captured == {"base_url": "https://saved.example/v1", "api_key": "sk-saved"}
+
+
+def test_openai_models_hide_upstream_exception_details(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+
+    def fake_list_models(*, base_url: str, api_key: str) -> list[str]:
+        raise ValueError(f"upstream rejected {api_key}")
+
+    monkeypatch.setattr(main, "list_openai_models", fake_list_models)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/settings/openai/models",
+        json={"base_url": "https://other.example/v1", "api_key": "sk-temporary"},
+    )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Failed to fetch models from the OpenAI-compatible API."
+    assert "sk-temporary" not in response.text
+
+
+def test_openai_settings_reject_invalid_base_url(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    client = TestClient(main.app)
+
+    response = client.post(
+        "/api/settings/openai",
+        json={
+            "base_url": "ftp://api.example.com/v1",
+            "api_key": "sk-temporary",
+            "model": "model",
+            "translate_concurrency": "10",
+        },
+    )
+
+    assert response.status_code == 422
+    assert "sk-temporary" not in response.text
+
+
+def test_openai_settings_reject_base_change_that_would_reuse_saved_key(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    database.save_openai_settings("https://saved.example/v1", "sk-saved", "saved-model")
+    captured = {}
+
+    def fake_list_models(*, base_url: str, api_key: str) -> list[str]:
+        captured.update(base_url=base_url, api_key=api_key)
+        return ["saved-model"]
+
+    monkeypatch.setattr(main, "list_openai_models", fake_list_models)
+    client = TestClient(main.app)
+
+    update_response = client.post(
+        "/api/settings/openai",
+        json={
+            "base_url": "https://other.example/v1",
+            "api_key": "",
+            "model": "other-model",
+            "translate_concurrency": "10",
+        },
+    )
+    models_response = client.post(
+        "/api/settings/openai/models",
+        json={"base_url": "", "api_key": ""},
+    )
+
+    assert update_response.status_code == 422
+    assert "sk-saved" not in update_response.text
+    assert models_response.status_code == 200
+    assert captured == {"base_url": "https://saved.example/v1", "api_key": "sk-saved"}
+
+
+def test_openai_settings_update_is_atomically_visible(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    database.save_openai_settings("https://saved.example/v1", "sk-saved", "saved-model")
+    base_update_started = threading.Event()
+    allow_update_to_finish = threading.Event()
+    writer_errors: list[Exception] = []
+
+    def pause_after_base_update() -> int:
+        base_update_started.set()
+        assert allow_update_to_finish.wait(timeout=5)
+        return 0
+
+    def connect_with_pause() -> sqlite3.Connection:
+        conn = sqlite3.connect(database.DB_PATH)
+        conn.row_factory = sqlite3.Row
+        conn.create_function("pause_after_base_update", 0, pause_after_base_update)
+        return conn
+
+    monkeypatch.setattr(database, "connect", connect_with_pause)
+    with database.connect() as conn:
+        conn.execute(
+            """
+            CREATE TRIGGER pause_openai_base_update
+            AFTER UPDATE ON settings
+            WHEN NEW.key = 'openai.base_url'
+            BEGIN
+              SELECT pause_after_base_update();
+            END
+            """
+        )
+
+    def update_settings() -> None:
+        try:
+            database.save_openai_settings(
+                "https://other.example/v1",
+                "sk-other",
+                "other-model",
+                "10",
+            )
+        except Exception as exc:  # pragma: no cover - asserted below
+            writer_errors.append(exc)
+
+    writer = threading.Thread(target=update_settings)
+    writer.start()
+    assert base_update_started.wait(timeout=5)
+
+    during_update = database.get_openai_settings()
+    assert during_update["base_url"] == "https://saved.example/v1"
+    assert during_update["api_key"] == "sk-saved"
+
+    allow_update_to_finish.set()
+    writer.join(timeout=5)
+    assert writer.is_alive() is False
+    assert writer_errors == []
+
+    after_update = database.get_openai_settings()
+    assert after_update["base_url"] == "https://other.example/v1"
+    assert after_update["api_key"] == "sk-other"
+
+
+def test_openai_settings_read_uses_one_consistent_snapshot(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    database.save_openai_settings("https://saved.example/v1", "sk-saved", "saved-model")
+    with database.connect() as conn:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+
+    original_connect = database.connect
+    reader_started = threading.Event()
+    allow_reader_to_finish = threading.Event()
+    reader_results: list[dict[str, str]] = []
+    reader_errors: list[Exception] = []
+
+    class PausingCursor:
+        def __init__(self, cursor: sqlite3.Cursor):
+            self.cursor = cursor
+
+        def fetchall(self):
+            first_row = self.cursor.fetchone()
+            reader_started.set()
+            assert allow_reader_to_finish.wait(timeout=5)
+            remaining_rows = self.cursor.fetchall()
+            return ([first_row] if first_row is not None else []) + remaining_rows
+
+    class PausingConnection:
+        def __init__(self, conn: sqlite3.Connection):
+            self.conn = conn
+
+        def __enter__(self):
+            self.conn.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self.conn.__exit__(*args)
+
+        def execute(self, sql, parameters=()):
+            cursor = self.conn.execute(sql, parameters)
+            if "FROM settings WHERE key IN" in sql:
+                return PausingCursor(cursor)
+            return cursor
+
+    reader_thread: threading.Thread
+
+    def connect_with_pausing_reader():
+        conn = original_connect()
+        if threading.current_thread() is reader_thread:
+            return PausingConnection(conn)
+        return conn
+
+    monkeypatch.setattr(database, "connect", connect_with_pausing_reader)
+
+    def read_settings() -> None:
+        try:
+            reader_results.append(database.get_openai_settings())
+        except Exception as exc:  # pragma: no cover - asserted below
+            reader_errors.append(exc)
+
+    reader_thread = threading.Thread(target=read_settings)
+    reader_thread.start()
+    assert reader_started.wait(timeout=5)
+
+    database.save_openai_settings(
+        "https://other.example/v1",
+        "sk-other",
+        "other-model",
+        "10",
+    )
+    allow_reader_to_finish.set()
+    reader_thread.join(timeout=5)
+
+    assert reader_thread.is_alive() is False
+    assert reader_errors == []
+    assert reader_results == [
+        {
+            "base_url": "https://saved.example/v1",
+            "api_key": "sk-saved",
+            "model": "saved-model",
+            "translate_concurrency": "50",
+        }
+    ]
+    assert database.get_openai_settings() == {
+        "base_url": "https://other.example/v1",
+        "api_key": "sk-other",
+        "model": "other-model",
+        "translate_concurrency": "10",
+    }
+
+
 def test_openai_settings_include_translate_concurrency(monkeypatch, tmp_path):
     monkeypatch.delenv("OPENAI_TRANSLATE_CONCURRENCY", raising=False)
     configure_tmp_runtime(monkeypatch, tmp_path)
@@ -516,11 +800,12 @@ def test_openai_settings_include_translate_concurrency(monkeypatch, tmp_path):
 def test_openai_settings_persists_translate_concurrency(monkeypatch, tmp_path):
     configure_tmp_runtime(monkeypatch, tmp_path)
     client = TestClient(main.app)
+    saved_base_url = database.get_openai_settings()["base_url"]
 
     response = client.post(
         "/api/settings/openai",
         json={
-            "base_url": "https://example.com/v1",
+            "base_url": saved_base_url,
             "api_key": "",
             "model": "model",
             "translate_concurrency": " 32 ",
@@ -580,11 +865,12 @@ def test_openai_settings_empty_translate_concurrency_preserves_existing(monkeypa
 def test_openai_settings_accepts_translate_concurrency_boundaries(monkeypatch, tmp_path, value):
     configure_tmp_runtime(monkeypatch, tmp_path)
     client = TestClient(main.app)
+    saved_base_url = database.get_openai_settings()["base_url"]
 
     response = client.post(
         "/api/settings/openai",
         json={
-            "base_url": "https://example.com/v1",
+            "base_url": saved_base_url,
             "api_key": "",
             "clear_api_key": False,
             "model": "model",


### PR DESCRIPTION
## 问题

模型列表探测接口允许请求方只替换 OpenAI 兼容地址、同时复用数据库中保存的密钥，可能把密钥发送到非预期主机。设置字段分次读写时还可能在并发下形成跨版本的地址与密钥组合。

## 修复

- 校验 OpenAI 兼容地址，只接受不含凭据、查询串和片段的绝对 HTTP(S) 地址
- 仅当请求地址与保存地址等价时才允许复用保存密钥；切换地址必须显式提供新密钥
- 使用单一事务原子更新地址、模型、密钥和并发参数
- 使用单连接、单条查询读取完整设置快照
- 上游异常统一返回固定错误信息，避免响应泄露密钥
- 保留 localhost HTTP 兼容服务支持

## 验证

- 后端全量测试：179 项通过
- 定向设置与 OpenAI 客户端测试：79 项通过
- `git diff --check` 通过
- 独立安全复核通过，包括顺序两步链和 WAL 并发读写时序
