### PR TITLE
安全：收紧运行时敏感文件权限

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -294,6 +294,21 @@ When opening the app from LAN, WSL2, or another machine, use the actual frontend
 
 Browsers should always open the frontend URL and let Next.js forward `/api`; never place authentication data in `NEXT_PUBLIC_*`, URL queries, or browser storage. For LAN or public access, put the frontend behind an HTTPS reverse proxy and set `YOUDUB_AUTH_COOKIE_SECURE=true`. Plain HTTP is suitable only for trusted local development.
 
+### Runtime File Permissions
+
+On POSIX systems, the backend permanently sets process `umask 0077` before reading `.env`, opening SQLite, or starting the worker. Startup migration inspects filesystem metadata only; it does not read or rewrite file contents. The policy is:
+
+- Directories under `data/`, Cookie and log storage, and `WORKFOLDER` are restricted to `0700`; regular files are restricted to `0600`.
+- The SQLite database and its `-journal`, `-wal`, and `-shm` sidecars, `.env`, `env.txt`, cookies, uploads, and newly generated artifacts remain owner-only.
+- Symlinks, special files, foreign-owned nodes, or unsafe writable ancestors make startup fail closed; the worker does not start after a migration failure.
+- The `MODEL_CACHE_DIR` root must be owned by root or the service account and must not be writable by other users. A service-owned cache root is restricted to `0700`. Its contents are not recursively chmodded or validated, so any existing model cache must be trusted before deployment.
+
+Run the service under a dedicated OS account, and ensure that the repository and any custom `WORKFOLDER` parent cannot be renamed by untrusted groups or users. This boundary protects against other UIDs and untrusted groups; it does not protect against same-UID processes, debuggers, or root. Use a dedicated account, container, or service sandbox for stronger isolation.
+
+Before the first permission migration, stop any older instance that may still create or delete runtime files. If a concurrent startup fails closed during migration, stop the older instance and retry startup.
+
+On Windows, `chmod` and `umask` are not substitutes for NTFS ACLs. Restrict the DACL for the repository, `.env`, `env.txt`, `data`, and `WORKFOLDER` to the service account; the application's compatibility checks cannot replace correct ACLs. Real `.env`, `env.txt`, cookie, SQLite, `data/`, and `workfolder/` files are covered by `.gitignore`; never force-add them to Git.
+
 ## Using the Web UI
 
 1. Sign in with the access password whose hash you configured.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,21 @@ http://localhost:3000
 
 浏览器应始终访问前端地址，由 Next.js 转发 `/api`；不要把认证信息放进 `NEXT_PUBLIC_*`、URL query 或前端存储。通过局域网或公网访问时，请在前端前面配置 HTTPS 反向代理并设置 `YOUDUB_AUTH_COOKIE_SECURE=true`。明文 HTTP 只适用于可信的本机开发环境。
 
+### 运行时文件权限
+
+在 POSIX 系统上，后端会在读取 `.env`、连接 SQLite 或启动 worker 前永久设置进程 `umask 0077`。启动迁移只检查文件系统元数据，不读取或改写文件内容，并执行以下策略：
+
+- `data/`、Cookie、日志和 `WORKFOLDER` 下的目录收紧为 `0700`，普通文件收紧为 `0600`。
+- SQLite 主库和 `-journal`、`-wal`、`-shm` sidecar、`.env`、`env.txt`、Cookie、上传与新生成产物保持 owner-only。
+- 符号链接、特殊文件、异主文件和不安全的可写祖先会让启动失败；服务不会在权限迁移失败后继续启动 worker。
+- `MODEL_CACHE_DIR` 根目录必须由 root 或服务账号拥有且不可被其他用户写入；服务账号拥有的缓存根会收紧为 `0700`。缓存内部不做递归 chmod 或内容校验，因此部署前必须确认已有模型缓存可信。
+
+建议用专用 OS 用户运行服务，并确保仓库及自定义 `WORKFOLDER` 的父目录不允许其他组或用户重命名目录项。该边界防护其他 UID 或不可信组用户，不防同 UID 进程、调试器或 root；更强隔离请使用独立账号、容器或系统服务沙箱。
+
+首次启用或执行权限迁移时，应先停止仍会创建或删除运行时文件的旧实例；如果并行启动因 fail-closed 校验失败，请停止旧实例后重试启动。
+
+Windows 的 `chmod`/`umask` 不等价于 NTFS ACL。Windows 部署需由管理员把仓库、`.env`、`env.txt`、`data` 和 `WORKFOLDER` 的 DACL 限制到服务账号；应用会做兼容性检查，但不能替代正确的 NTFS ACL。真实 `.env`、`env.txt`、Cookie、SQLite、`data/` 和 `workfolder/` 已被 `.gitignore` 排除，不要强制加入 Git。
+
 ## 页面里怎么用
 
 1. 使用生成哈希时设置的访问密码登录。

--- a/backend/app/adapters/ytdlp.py
+++ b/backend/app/adapters/ytdlp.py
@@ -10,6 +10,7 @@ import time
 import requests
 import yt_dlp
 
+from .. import runtime_security
 from ..sanitize import sanitize_text
 from ..sources import SourceConfig
 from ..youtube import extract_video_id
@@ -41,8 +42,7 @@ def _bootstrap_bilibili_cookie(cookie_path: Path) -> None:
     cookies.setdefault("SESSDATA", "anonymous_for_webpage_playinfo")
     for name, value in cookies.items():
         lines.append("\t".join([".bilibili.com", "TRUE", "/", "FALSE", str(expires), name, value]))
-    cookie_path.parent.mkdir(parents=True, exist_ok=True)
-    cookie_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    runtime_security.atomic_write_private_text(cookie_path, "\n".join(lines) + "\n")
 
 
 def _proxy_url(proxy_port: str = "") -> str:
@@ -55,7 +55,8 @@ def _ensure_cookie(source: SourceConfig) -> None:
     cookie_path = source.cookie_path
     if not cookie_path or source.name != "bilibili":
         return
-    if cookie_path.exists() and cookie_path.stat().st_size > 0:
+    metadata = runtime_security.private_file_stat(cookie_path)
+    if metadata and metadata.st_size > 0:
         return
     _bootstrap_bilibili_cookie(cookie_path)
 
@@ -69,8 +70,10 @@ def _ydl_base(source: SourceConfig, proxy_port: str = "") -> dict[str, Any]:
         "http_headers": {"User-Agent": DEFAULT_USER_AGENT},
     }
     cookie_path = source.cookie_path
-    if cookie_path and cookie_path.exists() and cookie_path.stat().st_size > 0:
-        opts["cookiefile"] = str(cookie_path)
+    if cookie_path:
+        metadata = runtime_security.private_file_stat(cookie_path)
+        if metadata and metadata.st_size > 0:
+            opts["cookiefile"] = str(cookie_path)
     if not source.use_proxy:
         opts["proxy"] = ""
         return opts

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,13 +1,25 @@
 from __future__ import annotations
 
 import os
+import threading
 from pathlib import Path
 
 from dotenv import load_dotenv
 
-load_dotenv()
+from . import runtime_security
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+runtime_security.apply_private_umask()
+
+
+def _load_runtime_environment(repo_root: Path) -> None:
+    runtime_security.prepare_repository_root(repo_root)
+    runtime_security.secure_secret_aliases(repo_root / ".env", repo_root / "env.txt")
+    load_dotenv(repo_root / ".env")
+
+
+_load_runtime_environment(REPO_ROOT)
+
 DATA_DIR = REPO_ROOT / "data"
 COOKIE_DIR = DATA_DIR / "cookies"
 DB_PATH = DATA_DIR / "youdub.sqlite"
@@ -16,13 +28,53 @@ WORKFOLDER = Path(os.getenv("WORKFOLDER", str(REPO_ROOT / "workfolder"))).expand
 LOG_DIR = DATA_DIR / "logs"
 MODEL_CACHE_DIR = Path(os.getenv("MODEL_CACHE_DIR", str(DATA_DIR / "modelscope"))).expanduser()
 
+_RUNTIME_SECURITY_LOCK = threading.Lock()
+_RUNTIME_SECURITY_SIGNATURE: tuple[str, ...] | None = None
+
 
 def ensure_runtime_dirs() -> None:
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    COOKIE_DIR.mkdir(parents=True, exist_ok=True)
-    WORKFOLDER.mkdir(parents=True, exist_ok=True)
-    LOG_DIR.mkdir(parents=True, exist_ok=True)
-    MODEL_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    global _RUNTIME_SECURITY_SIGNATURE
+    signature = tuple(
+        os.path.abspath(os.fspath(path))
+        for path in (
+            DATA_DIR,
+            COOKIE_DIR,
+            WORKFOLDER,
+            LOG_DIR,
+            MODEL_CACHE_DIR,
+            DB_PATH,
+            REPO_ROOT / ".env",
+            REPO_ROOT / "env.txt",
+        )
+    )
+    with _RUNTIME_SECURITY_LOCK:
+        if _RUNTIME_SECURITY_SIGNATURE == signature:
+            return
+
+        runtime_security.validate_model_cache_location(
+            MODEL_CACHE_DIR,
+            private_roots=(DATA_DIR, WORKFOLDER),
+            protected_paths=(
+                COOKIE_DIR,
+                LOG_DIR,
+                DB_PATH,
+                REPO_ROOT / ".env",
+                REPO_ROOT / "env.txt",
+            ),
+        )
+        for directory in (DATA_DIR, COOKIE_DIR, WORKFOLDER, LOG_DIR):
+            runtime_security.ensure_private_directory(directory)
+        runtime_security.ensure_model_cache_directory(MODEL_CACHE_DIR)
+        runtime_security.migrate_private_runtime(
+            private_roots=(DATA_DIR, WORKFOLDER),
+            exclude_roots=(MODEL_CACHE_DIR,),
+            ephemeral_files=runtime_security.sqlite_sidecar_paths(DB_PATH),
+        )
+        runtime_security.secure_secret_aliases(
+            REPO_ROOT / ".env", REPO_ROOT / "env.txt"
+        )
+        runtime_security.secure_sqlite_files(DB_PATH)
+        _RUNTIME_SECURITY_SIGNATURE = signature
 
 
 def device() -> str:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from . import config, runtime_security
 from .config import DB_PATH, ensure_runtime_dirs, openai_defaults, ytdlp_defaults
 from .stages import STAGES
 
@@ -20,13 +21,22 @@ def now_iso() -> str:
 
 
 def connect() -> sqlite3.Connection:
-    ensure_runtime_dirs()
+    if Path(DB_PATH).absolute() == Path(config.DB_PATH).absolute():
+        ensure_runtime_dirs()
+    runtime_security.secure_sqlite_database_file(DB_PATH)
     conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    return conn
+    try:
+        runtime_security.secure_sqlite_database_file(DB_PATH)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except Exception:
+        conn.close()
+        raise
 
 
 def init_db() -> None:
+    if Path(DB_PATH).absolute() == Path(config.DB_PATH).absolute():
+        ensure_runtime_dirs()
     with connect() as conn:
         conn.executescript(
             """
@@ -650,4 +660,6 @@ def save_ytdlp_settings(proxy_port: str) -> None:
 def log_path(task_id: str) -> Path:
     from .config import LOG_DIR
 
+    if Path(DB_PATH).absolute() != Path(config.DB_PATH).absolute():
+        return Path(DB_PATH).absolute().parent / "logs" / f"{task_id}.log"
     return LOG_DIR / f"{task_id}.log"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from pydantic import BaseModel, SecretStr
 
-from . import auth, database, worker
+from . import auth, database, runtime_security, worker
 from .adapters.local_subtitles import parse_srt, uploaded_subtitle_dir
 from .adapters.local_video import remove_upload, uploaded_video_dir
 from .adapters.openai_client import validate_openai_base_url
@@ -119,8 +119,8 @@ def normalize_translate_concurrency(value: str) -> str:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    auth.validate_auth_configuration()
     ensure_runtime_dirs()
+    auth.validate_auth_configuration()
     database.init_db()
     database.delete_expired_auth_sessions(database.now_iso())
     database.backfill_titles_from_metadata()
@@ -363,19 +363,24 @@ def _clean_subtitle_filename(filename: str | None) -> str:
 
 def _save_uploaded_file(file: UploadFile, destination: Path, *, max_bytes: int, too_large_detail: str) -> int:
     total = 0
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    with destination.open("wb") as handle:
-        while True:
-            chunk = file.file.read(LOCAL_UPLOAD_CHUNK_SIZE)
-            if not chunk:
-                break
-            total += len(chunk)
-            if total > max_bytes:
-                destination.unlink(missing_ok=True)
-                raise HTTPException(status_code=413, detail=too_large_detail)
-            handle.write(chunk)
+    created = False
+    try:
+        with runtime_security.open_private_binary_exclusive(destination) as handle:
+            created = True
+            while True:
+                chunk = file.file.read(LOCAL_UPLOAD_CHUNK_SIZE)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > max_bytes:
+                    raise HTTPException(status_code=413, detail=too_large_detail)
+                handle.write(chunk)
+    except Exception:
+        if created:
+            runtime_security.remove_private_file(destination, missing_ok=True)
+        raise
     if total == 0:
-        destination.unlink(missing_ok=True)
+        runtime_security.remove_private_file(destination, missing_ok=True)
         raise HTTPException(status_code=422, detail="Uploaded file is empty.")
     return total
 
@@ -599,20 +604,20 @@ def final_video(task_id: str, download: bool = False) -> FileResponse:
 
 @app.get("/api/cookies/youtube")
 def get_youtube_cookie() -> dict:
-    exists = YOUTUBE_COOKIE_PATH.exists()
-    size = YOUTUBE_COOKIE_PATH.stat().st_size if exists else 0
-    updated_at = YOUTUBE_COOKIE_PATH.stat().st_mtime if exists else None
+    metadata = runtime_security.private_file_stat(YOUTUBE_COOKIE_PATH)
+    exists = metadata is not None
+    size = metadata.st_size if metadata else 0
+    updated_at = metadata.st_mtime if metadata else None
     return {"exists": exists, "size": size, "updated_at": updated_at, "content": ""}
 
 
 @app.post("/api/cookies/youtube")
 def save_youtube_cookie(payload: YouTubeCookieUpdate) -> dict:
-    YOUTUBE_COOKIE_PATH.parent.mkdir(parents=True, exist_ok=True)
     content = payload.content.strip()
     if content:
-        YOUTUBE_COOKIE_PATH.write_text(content + "\n", encoding="utf-8")
-    elif YOUTUBE_COOKIE_PATH.exists():
-        YOUTUBE_COOKIE_PATH.unlink()
+        runtime_security.atomic_write_private_text(YOUTUBE_COOKIE_PATH, content + "\n")
+    else:
+        runtime_security.remove_private_file(YOUTUBE_COOKIE_PATH, missing_ok=True)
     return get_youtube_cookie()
 
 

--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from time import monotonic
 from typing import Callable
 
-from . import database
+from . import database, runtime_security
 from .config import WORKFOLDER
 from .devices import device_plan_summary
 from .runtime_checks import validate_runtime_device
@@ -34,9 +34,8 @@ class PipelineArtifacts:
 
 def _write_log(task_id: str, message: str) -> None:
     path = database.log_path(task_id)
-    path.parent.mkdir(parents=True, exist_ok=True)
     timestamp = database.now_iso()
-    with path.open("a", encoding="utf-8") as handle:
+    with runtime_security.open_private_append_text(path) as handle:
         for line in message.rstrip().splitlines() or [""]:
             handle.write(f"[{timestamp}] {line}\n")
 

--- a/backend/app/runtime_security.py
+++ b/backend/app/runtime_security.py
@@ -1,0 +1,586 @@
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import BinaryIO, Iterable, TextIO
+
+
+PRIVATE_DIR_MODE = 0o700
+PRIVATE_FILE_MODE = 0o600
+PRIVATE_UMASK = 0o077
+POSIX_STRONG_PERMISSIONS = os.name == "posix"
+RUNTIME_SECURITY_MODE = (
+    "posix-strong" if POSIX_STRONG_PERMISSIONS else "windows-best-effort"
+)
+
+
+class RuntimeSecurityError(RuntimeError):
+    """A runtime path cannot be used without weakening local data isolation."""
+
+
+def apply_private_umask() -> str:
+    """Permanently restrict newly created process and subprocess files on POSIX."""
+    if POSIX_STRONG_PERMISSIONS:
+        os.umask(PRIVATE_UMASK)
+    return RUNTIME_SECURITY_MODE
+
+
+def _absolute(path: Path | str) -> Path:
+    return Path(os.path.abspath(os.fspath(path)))
+
+
+def _is_link_like(path: Path, metadata: os.stat_result | None = None) -> bool:
+    if metadata is not None and stat.S_ISLNK(metadata.st_mode):
+        return True
+    if path.is_symlink():
+        return True
+    is_junction = getattr(path, "is_junction", None)
+    return bool(is_junction and is_junction())
+
+
+def _effective_uid() -> int | None:
+    getter = getattr(os, "geteuid", None)
+    return getter() if getter is not None else None
+
+
+def _validate_owner(path: Path, metadata: os.stat_result) -> None:
+    if not POSIX_STRONG_PERMISSIONS:
+        return
+    effective_uid = _effective_uid()
+    if effective_uid is not None and metadata.st_uid != effective_uid:
+        raise RuntimeSecurityError(f"Runtime path is not owned by the service user: {path}")
+
+
+def _validate_parent_chain(path: Path | str) -> None:
+    """Reject replaceable or redirected existing ancestors without resolving links."""
+    if not POSIX_STRONG_PERMISSIONS:
+        return
+
+    current = _absolute(path).parent
+    effective_uid = _effective_uid()
+    while True:
+        try:
+            metadata = os.lstat(current)
+        except FileNotFoundError:
+            metadata = None
+
+        if metadata is not None:
+            if _is_link_like(current, metadata) or not stat.S_ISDIR(metadata.st_mode):
+                raise RuntimeSecurityError(f"Runtime parent is not a real directory: {current}")
+            if effective_uid is not None and metadata.st_uid not in {0, effective_uid}:
+                raise RuntimeSecurityError(
+                    f"Runtime parent is owned by an untrusted user: {current}"
+                )
+            writable_by_others = stat.S_IMODE(metadata.st_mode) & 0o022
+            sticky = bool(metadata.st_mode & stat.S_ISVTX)
+            if writable_by_others and not sticky:
+                raise RuntimeSecurityError(
+                    f"Runtime parent is writable by group or other users: {current}"
+                )
+
+        parent = current.parent
+        if parent == current:
+            break
+        current = parent
+
+
+def _nofollow_flags(flags: int) -> int:
+    return flags | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+
+
+def _validate_directory_metadata(path: Path, metadata: os.stat_result) -> None:
+    if _is_link_like(path, metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise RuntimeSecurityError(f"Runtime directory is a link or special file: {path}")
+    _validate_owner(path, metadata)
+
+
+def _validate_file_metadata(path: Path, metadata: os.stat_result) -> None:
+    if _is_link_like(path, metadata) or not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeSecurityError(f"Runtime file is a link or special file: {path}")
+    _validate_owner(path, metadata)
+    if POSIX_STRONG_PERMISSIONS and metadata.st_nlink != 1:
+        raise RuntimeSecurityError(f"Runtime file has multiple hard links: {path}")
+
+
+def _secure_open_fd_without_mode_change(path: Path, *, directory: bool) -> int:
+    flags = os.O_RDONLY
+    if directory:
+        flags |= getattr(os, "O_DIRECTORY", 0)
+    try:
+        fd = os.open(path, _nofollow_flags(flags))
+    except OSError as exc:
+        kind = "directory" if directory else "file"
+        raise RuntimeSecurityError(f"Cannot safely open runtime {kind}: {path}") from exc
+
+    try:
+        metadata = os.fstat(fd)
+        if directory:
+            _validate_directory_metadata(path, metadata)
+        else:
+            _validate_file_metadata(path, metadata)
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def _secure_open_fd(path: Path, *, directory: bool) -> int:
+    fd = _secure_open_fd_without_mode_change(path, directory=directory)
+    try:
+        metadata = os.fstat(fd)
+        expected_mode = PRIVATE_DIR_MODE if directory else PRIVATE_FILE_MODE
+        if POSIX_STRONG_PERMISSIONS and stat.S_IMODE(metadata.st_mode) != expected_mode:
+            os.fchmod(fd, expected_mode)
+    except Exception:
+        os.close(fd)
+        raise
+    return fd
+
+
+def ensure_private_directory(path: Path | str) -> Path:
+    target = _absolute(path)
+    _validate_parent_chain(target)
+    try:
+        target.mkdir(mode=PRIVATE_DIR_MODE, parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeSecurityError(f"Cannot create private runtime directory: {target}") from exc
+    if POSIX_STRONG_PERMISSIONS:
+        fd = _secure_open_fd(target, directory=True)
+        os.close(fd)
+    else:
+        metadata = os.lstat(target)
+        _validate_directory_metadata(target, metadata)
+    return target
+
+
+def prepare_repository_root(path: Path | str) -> Path:
+    """Make an owner-controlled source root non-replaceable without making it private."""
+    target = _absolute(path)
+    _validate_parent_chain(target)
+    try:
+        metadata = os.lstat(target)
+    except OSError as exc:
+        raise RuntimeSecurityError(f"Cannot inspect repository root: {target}") from exc
+    _validate_directory_metadata(target, metadata)
+    if POSIX_STRONG_PERMISSIONS:
+        fd = _secure_open_fd_without_mode_change(target, directory=True)
+        try:
+            current_mode = stat.S_IMODE(os.fstat(fd).st_mode)
+            safe_mode = current_mode & ~0o022
+            if safe_mode != current_mode:
+                os.fchmod(fd, safe_mode)
+        finally:
+            os.close(fd)
+    return target
+
+
+def ensure_model_cache_directory(path: Path | str) -> Path:
+    """Create a cache root without recursively changing a shared existing cache."""
+    target = _absolute(path)
+    _validate_parent_chain(target)
+    try:
+        target.mkdir(mode=PRIVATE_DIR_MODE, parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeSecurityError(f"Cannot create model cache directory: {target}") from exc
+    metadata = os.lstat(target)
+    if _is_link_like(target, metadata) or not stat.S_ISDIR(metadata.st_mode):
+        raise RuntimeSecurityError(f"Model cache root is a link or special file: {target}")
+    if POSIX_STRONG_PERMISSIONS:
+        flags = _nofollow_flags(os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        try:
+            fd = os.open(target, flags)
+        except OSError as exc:
+            raise RuntimeSecurityError(
+                f"Cannot safely open model cache root: {target}"
+            ) from exc
+        try:
+            metadata = os.fstat(fd)
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise RuntimeSecurityError(
+                    f"Model cache root is not a real directory: {target}"
+                )
+            effective_uid = _effective_uid()
+            if metadata.st_uid == 0:
+                if stat.S_IMODE(metadata.st_mode) & 0o022:
+                    raise RuntimeSecurityError(
+                        f"Root-owned model cache is writable by group or other users: {target}"
+                    )
+            elif effective_uid is None or metadata.st_uid != effective_uid:
+                raise RuntimeSecurityError(
+                    f"Model cache root is owned by an untrusted user: {target}"
+                )
+            elif stat.S_IMODE(metadata.st_mode) != PRIVATE_DIR_MODE:
+                os.fchmod(fd, PRIVATE_DIR_MODE)
+        finally:
+            os.close(fd)
+    return target
+
+
+def secure_existing_file(path: Path | str, *, required: bool = False) -> os.stat_result | None:
+    target = _absolute(path)
+    _validate_parent_chain(target)
+    try:
+        metadata = os.lstat(target)
+    except FileNotFoundError:
+        if required:
+            raise RuntimeSecurityError(f"Required runtime file is missing: {target}")
+        return None
+    _validate_file_metadata(target, metadata)
+    if not POSIX_STRONG_PERMISSIONS:
+        return metadata
+    fd = _secure_open_fd(target, directory=False)
+    try:
+        return os.fstat(fd)
+    finally:
+        os.close(fd)
+
+
+def secure_secret_aliases(first_path: Path | str, second_path: Path | str) -> None:
+    """Secure the one explicitly supported `.env`/`env.txt` hard-link pair."""
+    targets = (_absolute(first_path), _absolute(second_path))
+    entries: list[tuple[Path, os.stat_result]] = []
+    for target in targets:
+        _validate_parent_chain(target)
+        try:
+            metadata = os.lstat(target)
+        except FileNotFoundError:
+            continue
+        if _is_link_like(target, metadata) or not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeSecurityError(f"Secret file is a link or special file: {target}")
+        _validate_owner(target, metadata)
+        entries.append((target, metadata))
+
+    if not entries:
+        return
+    if len(entries) == 1:
+        target, metadata = entries[0]
+        if POSIX_STRONG_PERMISSIONS and metadata.st_nlink != 1:
+            raise RuntimeSecurityError(f"Secret file has an unapproved hard link: {target}")
+        secure_existing_file(target, required=True)
+        return
+
+    first_target, first_metadata = entries[0]
+    second_target, second_metadata = entries[1]
+    same_inode = (
+        first_metadata.st_dev == second_metadata.st_dev
+        and first_metadata.st_ino == second_metadata.st_ino
+    )
+    if not same_inode:
+        for target, metadata in entries:
+            if POSIX_STRONG_PERMISSIONS and metadata.st_nlink != 1:
+                raise RuntimeSecurityError(
+                    f"Secret file has an unapproved hard link: {target}"
+                )
+            secure_existing_file(target, required=True)
+        return
+
+    if POSIX_STRONG_PERMISSIONS and (
+        first_metadata.st_nlink != 2 or second_metadata.st_nlink != 2
+    ):
+        raise RuntimeSecurityError("Secret aliases have an unapproved third hard link.")
+    if not POSIX_STRONG_PERMISSIONS:
+        return
+
+    expected_identity = (first_metadata.st_dev, first_metadata.st_ino)
+    for target, _ in entries:
+        try:
+            fd = os.open(target, _nofollow_flags(os.O_RDONLY))
+        except OSError as exc:
+            raise RuntimeSecurityError(f"Cannot safely open secret alias: {target}") from exc
+        try:
+            metadata = os.fstat(fd)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != _effective_uid()
+                or metadata.st_nlink != 2
+                or (metadata.st_dev, metadata.st_ino) != expected_identity
+            ):
+                raise RuntimeSecurityError(f"Secret alias changed during validation: {target}")
+            if stat.S_IMODE(metadata.st_mode) != PRIVATE_FILE_MODE:
+                os.fchmod(fd, PRIVATE_FILE_MODE)
+        finally:
+            os.close(fd)
+
+
+def private_file_stat(path: Path | str) -> os.stat_result | None:
+    """Return no-follow metadata after validating a private regular file."""
+    return secure_existing_file(path)
+
+
+def remove_private_file(path: Path | str, *, missing_ok: bool = False) -> None:
+    target = _absolute(path)
+    metadata = secure_existing_file(target)
+    if metadata is None:
+        if missing_ok:
+            return
+        raise FileNotFoundError(target)
+    try:
+        target.unlink()
+    except FileNotFoundError:
+        if not missing_ok:
+            raise
+
+
+def _is_within_or_equal(path: Path, parent: Path) -> bool:
+    target = os.fspath(_absolute(path))
+    container = os.fspath(_absolute(parent))
+    try:
+        return os.path.commonpath((target, container)) == container
+    except ValueError:
+        return False
+
+
+def _is_excluded(path: Path, exclusions: tuple[Path, ...]) -> bool:
+    for exclusion in exclusions:
+        if _is_within_or_equal(path, exclusion):
+            return True
+    return False
+
+
+def validate_model_cache_location(
+    model_cache: Path | str,
+    *,
+    private_roots: Iterable[Path | str],
+    protected_paths: Iterable[Path | str] = (),
+) -> None:
+    cache = _absolute(model_cache)
+    for root_value in private_roots:
+        root = _absolute(root_value)
+        if _is_within_or_equal(root, cache):
+            raise RuntimeSecurityError(
+                f"Model cache cannot equal or contain a private runtime root: {cache}"
+            )
+    for protected_value in protected_paths:
+        protected = _absolute(protected_value)
+        if _is_within_or_equal(cache, protected) or _is_within_or_equal(
+            protected, cache
+        ):
+            raise RuntimeSecurityError(
+                f"Model cache overlaps protected runtime data: {cache}"
+            )
+
+
+def secure_private_tree(
+    root: Path | str,
+    *,
+    exclude_roots: Iterable[Path | str] = (),
+    ephemeral_files: Iterable[Path | str] = (),
+) -> None:
+    target = ensure_private_directory(root)
+    ephemeral_paths = frozenset(_absolute(value) for value in ephemeral_files)
+    exclusions: list[Path] = []
+    for value in exclude_roots:
+        exclusion = _absolute(value)
+        if _is_within_or_equal(target, exclusion):
+            raise RuntimeSecurityError(
+                f"Excluded path cannot equal or contain a private runtime root: {exclusion}"
+            )
+        if _is_within_or_equal(exclusion, target):
+            exclusions.append(exclusion)
+    exclusion_tuple = tuple(exclusions)
+
+    for current, directory_names, file_names in os.walk(target, topdown=True, followlinks=False):
+        current_path = Path(current)
+        kept_directories: list[str] = []
+        for name in directory_names:
+            child = current_path / name
+            if _is_excluded(child, exclusion_tuple):
+                continue
+            if POSIX_STRONG_PERMISSIONS:
+                fd = _secure_open_fd(child, directory=True)
+                os.close(fd)
+            else:
+                metadata = os.lstat(child)
+                _validate_directory_metadata(child, metadata)
+            kept_directories.append(name)
+        directory_names[:] = kept_directories
+        for name in file_names:
+            child = current_path / name
+            if _is_excluded(child, exclusion_tuple):
+                continue
+            if _absolute(child) in ephemeral_paths:
+                secure_sqlite_sidecar_file(child)
+            else:
+                secure_existing_file(child, required=True)
+
+
+def migrate_private_runtime(
+    *,
+    private_roots: Iterable[Path | str],
+    secret_files: Iterable[Path | str] = (),
+    exclude_roots: Iterable[Path | str] = (),
+    ephemeral_files: Iterable[Path | str] = (),
+) -> None:
+    exclusions = tuple(exclude_roots)
+    ephemeral_paths = tuple(ephemeral_files)
+    for root in private_roots:
+        secure_private_tree(
+            root,
+            exclude_roots=exclusions,
+            ephemeral_files=ephemeral_paths,
+        )
+    for path in secret_files:
+        secure_existing_file(path)
+
+
+def sqlite_sidecar_paths(database_path: Path | str) -> tuple[Path, ...]:
+    database_file = _absolute(database_path)
+    return tuple(Path(f"{database_file}{suffix}") for suffix in ("-wal", "-shm", "-journal"))
+
+
+def secure_sqlite_files(database_path: Path | str) -> None:
+    database_file = _absolute(database_path)
+    ensure_private_directory(database_file.parent)
+    secure_existing_file(database_file)
+    for sidecar in sqlite_sidecar_paths(database_file):
+        secure_sqlite_sidecar_file(sidecar)
+
+
+def _validate_sqlite_sidecar_metadata(
+    path: Path,
+    metadata: os.stat_result,
+    *,
+    allow_unlinked: bool,
+) -> None:
+    if _is_link_like(path, metadata) or not stat.S_ISREG(metadata.st_mode):
+        raise RuntimeSecurityError(f"SQLite sidecar is a link or special file: {path}")
+    _validate_owner(path, metadata)
+    if not POSIX_STRONG_PERMISSIONS:
+        return
+    if metadata.st_nlink > 1 or (metadata.st_nlink == 0 and not allow_unlinked):
+        raise RuntimeSecurityError(f"SQLite sidecar has an unsafe link count: {path}")
+
+
+def secure_sqlite_sidecar_file(path: Path | str) -> os.stat_result | None:
+    """Secure one exact SQLite sidecar while tolerating SQLite unlink races."""
+    target = _absolute(path)
+    _validate_parent_chain(target)
+    for _ in range(8):
+        try:
+            metadata = os.lstat(target)
+        except FileNotFoundError:
+            return None
+        _validate_sqlite_sidecar_metadata(
+            target,
+            metadata,
+            allow_unlinked=False,
+        )
+        if not POSIX_STRONG_PERMISSIONS:
+            return metadata
+
+        try:
+            fd = os.open(target, _nofollow_flags(os.O_RDONLY))
+        except FileNotFoundError:
+            try:
+                replacement = os.lstat(target)
+            except FileNotFoundError:
+                return None
+            _validate_sqlite_sidecar_metadata(
+                target,
+                replacement,
+                allow_unlinked=False,
+            )
+            continue
+        except OSError as exc:
+            raise RuntimeSecurityError(
+                f"Cannot safely open SQLite sidecar: {target}"
+            ) from exc
+
+        try:
+            metadata = os.fstat(fd)
+            _validate_sqlite_sidecar_metadata(
+                target,
+                metadata,
+                allow_unlinked=True,
+            )
+            if metadata.st_nlink == 0:
+                return metadata
+            if stat.S_IMODE(metadata.st_mode) != PRIVATE_FILE_MODE:
+                os.fchmod(fd, PRIVATE_FILE_MODE)
+            return os.fstat(fd)
+        finally:
+            os.close(fd)
+
+    raise RuntimeSecurityError(f"SQLite sidecar changed repeatedly: {target}")
+
+
+def secure_sqlite_database_file(database_path: Path | str) -> None:
+    """Secure only the stable database path, safe for concurrent connect churn."""
+    database_file = _absolute(database_path)
+    ensure_private_directory(database_file.parent)
+    secure_existing_file(database_file)
+
+
+def _validate_new_fd(path: Path, fd: int, *, file_mode: int = PRIVATE_FILE_MODE) -> None:
+    metadata = os.fstat(fd)
+    _validate_file_metadata(path, metadata)
+    if POSIX_STRONG_PERMISSIONS and stat.S_IMODE(metadata.st_mode) != file_mode:
+        os.fchmod(fd, file_mode)
+
+
+def atomic_write_private_text(path: Path | str, content: str, *, encoding: str = "utf-8") -> None:
+    target = _absolute(path)
+    parent = ensure_private_directory(target.parent)
+    secure_existing_file(target)
+
+    fd = -1
+    temporary_path: Path | None = None
+    try:
+        fd, raw_temporary_path = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            dir=parent,
+        )
+        temporary_path = Path(raw_temporary_path)
+        _validate_new_fd(temporary_path, fd)
+        with os.fdopen(fd, "w", encoding=encoding, newline="") as handle:
+            fd = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, target)
+        temporary_path = None
+        secure_existing_file(target, required=True)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def open_private_append_text(
+    path: Path | str,
+    *,
+    encoding: str = "utf-8",
+) -> TextIO:
+    target = _absolute(path)
+    ensure_private_directory(target.parent)
+    flags = _nofollow_flags(os.O_WRONLY | os.O_CREAT | os.O_APPEND)
+    try:
+        fd = os.open(target, flags, PRIVATE_FILE_MODE)
+    except OSError as exc:
+        raise RuntimeSecurityError(f"Cannot safely append to runtime file: {target}") from exc
+    try:
+        _validate_new_fd(target, fd)
+        return os.fdopen(fd, "a", encoding=encoding)
+    except Exception:
+        os.close(fd)
+        raise
+
+
+def open_private_binary_exclusive(path: Path | str) -> BinaryIO:
+    target = _absolute(path)
+    ensure_private_directory(target.parent)
+    flags = _nofollow_flags(os.O_WRONLY | os.O_CREAT | os.O_EXCL)
+    try:
+        fd = os.open(target, flags, PRIVATE_FILE_MODE)
+    except OSError as exc:
+        raise RuntimeSecurityError(f"Cannot safely create runtime file: {target}") from exc
+    try:
+        _validate_new_fd(target, fd)
+        return os.fdopen(fd, "wb")
+    except Exception:
+        os.close(fd)
+        raise

--- a/backend/tests/test_file_permissions.py
+++ b/backend/tests/test_file_permissions.py
@@ -1,0 +1,690 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sqlite3
+import stat
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.app import config, database, main, pipeline, runtime_security
+
+
+POSIX_ONLY = pytest.mark.skipif(
+    not runtime_security.POSIX_STRONG_PERMISSIONS,
+    reason="POSIX permission bits are not a Windows ACL guarantee.",
+)
+
+
+def _mode(path: Path) -> int:
+    return stat.S_IMODE(path.lstat().st_mode)
+
+
+def _make_safe_directory(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    if runtime_security.POSIX_STRONG_PERMISSIONS:
+        path.chmod(0o700)
+    return path
+
+
+@POSIX_ONLY
+def test_private_umask_is_inherited_by_external_process(tmp_path):
+    root = _make_safe_directory(tmp_path / "umask")
+    previous = os.umask(0)
+    try:
+        assert runtime_security.apply_private_umask() == "posix-strong"
+        script = (
+            "from pathlib import Path; "
+            "root=Path(__import__('sys').argv[1]); "
+            "(root/'child').mkdir(); "
+            "(root/'child'/'artifact.bin').write_bytes(b'x')"
+        )
+        subprocess.run([sys.executable, "-c", script, str(root)], check=True)
+    finally:
+        os.umask(previous)
+
+    assert _mode(root / "child") == 0o700
+    assert _mode(root / "child" / "artifact.bin") == 0o600
+
+
+@POSIX_ONLY
+def test_metadata_only_migration_preserves_content_and_mtime_and_skips_model_cache(
+    tmp_path,
+):
+    root = _make_safe_directory(tmp_path / "runtime")
+    data = root / "data"
+    workfolder = root / "workfolder"
+    cookie_dir = data / "cookies"
+    log_dir = data / "logs"
+    model_cache = data / "modelscope"
+    for directory in (data, workfolder, cookie_dir, log_dir, model_cache):
+        directory.mkdir(parents=True, exist_ok=True)
+        directory.chmod(0o777 if directory != model_cache else 0o755)
+
+    sensitive_files = [
+        data / "youdub.sqlite",
+        cookie_dir / "youtube.txt",
+        log_dir / "task.log",
+        workfolder / "artifact.json",
+        root / ".env",
+        root / "env.txt",
+    ]
+    for index, path in enumerate(sensitive_files):
+        path.write_bytes(f"synthetic-{index}".encode())
+        path.chmod(0o666)
+        timestamp_ns = 1_700_000_000_000_000_000 + index
+        os.utime(path, ns=(timestamp_ns, timestamp_ns))
+
+    model_file = model_cache / "weights.bin"
+    model_file.write_bytes(b"public-model")
+    model_file.chmod(0o644)
+    before = {
+        path: (path.read_bytes(), path.stat().st_mtime_ns) for path in sensitive_files
+    }
+
+    runtime_security.validate_model_cache_location(
+        model_cache,
+        private_roots=(data, workfolder),
+        protected_paths=(cookie_dir, log_dir, data / "youdub.sqlite"),
+    )
+    runtime_security.migrate_private_runtime(
+        private_roots=(data, workfolder),
+        secret_files=(root / ".env", root / "env.txt"),
+        exclude_roots=(model_cache,),
+    )
+
+    for directory in (data, workfolder, cookie_dir, log_dir):
+        assert _mode(directory) == 0o700
+    for path, (content, mtime_ns) in before.items():
+        assert _mode(path) == 0o600
+        assert path.read_bytes() == content
+        assert path.stat().st_mtime_ns == mtime_ns
+    assert _mode(model_cache) == 0o755
+    assert _mode(model_file) == 0o644
+
+
+@POSIX_ONLY
+def test_unsafe_parent_is_rejected(tmp_path):
+    unsafe_parent = tmp_path / "shared"
+    unsafe_parent.mkdir()
+    unsafe_parent.chmod(0o770)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError, match="writable"):
+        runtime_security.ensure_private_directory(unsafe_parent / "data")
+
+
+@POSIX_ONLY
+def test_repository_and_env_are_secured_before_dotenv_loader(monkeypatch, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    repo.chmod(0o775)
+    env_file = repo / ".env"
+    env_txt = repo / "env.txt"
+    env_file.write_bytes(b"SYNTHETIC=value\n")
+    env_txt.write_bytes(b"SYNTHETIC_EDIT=value\n")
+    env_file.chmod(0o664)
+    env_txt.chmod(0o664)
+    called = []
+
+    def fake_loader(path):
+        called.append(Path(path))
+        assert _mode(repo) == 0o755
+        assert _mode(env_file) == 0o600
+        assert _mode(env_txt) == 0o600
+
+    monkeypatch.setattr(config, "load_dotenv", fake_loader)
+    config._load_runtime_environment(repo)
+
+    assert called == [env_file]
+
+
+@POSIX_ONLY
+def test_only_the_known_env_alias_pair_is_allowed(monkeypatch, tmp_path):
+    repo = _make_safe_directory(tmp_path / "repo-alias")
+    env_file = repo / ".env"
+    env_txt = repo / "env.txt"
+    env_file.write_bytes(b"SYNTHETIC=value\n")
+    os.link(env_file, env_txt)
+    env_file.chmod(0o664)
+    called = []
+    monkeypatch.setattr(config, "load_dotenv", lambda path: called.append(Path(path)))
+
+    config._load_runtime_environment(repo)
+
+    assert called == [env_file]
+    assert env_file.stat().st_ino == env_txt.stat().st_ino
+    assert env_file.stat().st_nlink == 2
+    assert _mode(env_file) == 0o600
+
+
+@POSIX_ONLY
+def test_env_alias_pair_rejects_a_third_hard_link(monkeypatch, tmp_path):
+    repo = _make_safe_directory(tmp_path / "repo-third-link")
+    env_file = repo / ".env"
+    env_txt = repo / "env.txt"
+    third = repo / "unexpected"
+    env_file.write_bytes(b"SYNTHETIC=value\n")
+    os.link(env_file, env_txt)
+    os.link(env_file, third)
+    called = []
+    monkeypatch.setattr(config, "load_dotenv", lambda path: called.append(Path(path)))
+
+    with pytest.raises(runtime_security.RuntimeSecurityError, match="third"):
+        config._load_runtime_environment(repo)
+
+    assert called == []
+
+
+@POSIX_ONLY
+def test_dotenv_symlink_is_rejected_before_loader(monkeypatch, tmp_path):
+    repo = _make_safe_directory(tmp_path / "repo-link")
+    outside = repo.parent / "outside.env"
+    outside.write_bytes(b"SYNTHETIC=value\n")
+    outside.chmod(0o640)
+    (repo / ".env").symlink_to(outside)
+    called = []
+    monkeypatch.setattr(config, "load_dotenv", lambda path: called.append(path))
+    outside_before = (outside.read_bytes(), _mode(outside), outside.stat().st_mtime_ns)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        config._load_runtime_environment(repo)
+
+    assert called == []
+    assert (outside.read_bytes(), _mode(outside), outside.stat().st_mtime_ns) == outside_before
+
+
+@POSIX_ONLY
+def test_repository_root_rejects_untrusted_owner(monkeypatch, tmp_path):
+    repo = _make_safe_directory(tmp_path / "foreign-owner")
+    actual_uid = os.geteuid()
+    monkeypatch.setattr(runtime_security, "_validate_parent_chain", lambda path: None)
+    monkeypatch.setattr(runtime_security, "_effective_uid", lambda: actual_uid + 1)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError, match="owned"):
+        runtime_security.prepare_repository_root(repo)
+
+
+@POSIX_ONLY
+def test_repository_root_rejects_unsafe_ancestor(tmp_path):
+    unsafe_parent = tmp_path / "unsafe-repo-parent"
+    unsafe_parent.mkdir()
+    unsafe_parent.chmod(0o770)
+    repo = unsafe_parent / "repo"
+    repo.mkdir()
+
+    with pytest.raises(runtime_security.RuntimeSecurityError, match="writable"):
+        runtime_security.prepare_repository_root(repo)
+
+
+@POSIX_ONLY
+def test_model_cache_root_symlink_is_rejected(tmp_path):
+    outside = tmp_path / "models"
+    outside.mkdir()
+    linked = tmp_path / "model-cache"
+    linked.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        runtime_security.ensure_model_cache_directory(linked)
+
+
+@POSIX_ONLY
+def test_owner_model_cache_root_is_tightened_without_recursing(tmp_path):
+    cache = tmp_path / "model-cache-owner"
+    cache.mkdir()
+    cache.chmod(0o775)
+    model_file = cache / "weights.bin"
+    model_file.write_bytes(b"synthetic-model")
+    model_file.chmod(0o644)
+
+    runtime_security.ensure_model_cache_directory(cache)
+
+    assert _mode(cache) == 0o700
+    assert _mode(model_file) == 0o644
+
+
+@POSIX_ONLY
+@pytest.mark.parametrize("root_mode, rejected", [(0o755, False), (0o775, True)])
+def test_root_owned_model_cache_is_not_taken_over(
+    monkeypatch, tmp_path, root_mode, rejected
+):
+    cache = _make_safe_directory(tmp_path / f"root-cache-{root_mode:o}")
+    actual = cache.stat()
+    values = list(actual)
+    values[0] = (actual.st_mode & ~0o777) | root_mode
+    values[4] = 0
+    root_metadata = os.stat_result(values)
+    chmod_calls = []
+    monkeypatch.setattr(runtime_security, "_validate_parent_chain", lambda path: None)
+    monkeypatch.setattr(runtime_security, "_effective_uid", lambda: 1000)
+    monkeypatch.setattr(runtime_security.os, "fstat", lambda fd: root_metadata)
+    monkeypatch.setattr(
+        runtime_security.os,
+        "fchmod",
+        lambda fd, mode: chmod_calls.append((fd, mode)),
+    )
+
+    if rejected:
+        with pytest.raises(runtime_security.RuntimeSecurityError, match="Root-owned"):
+            runtime_security.ensure_model_cache_directory(cache)
+    else:
+        runtime_security.ensure_model_cache_directory(cache)
+
+    assert chmod_calls == []
+
+
+@POSIX_ONLY
+def test_model_cache_root_rejects_untrusted_owner(monkeypatch, tmp_path):
+    cache = _make_safe_directory(tmp_path / "model-cache-foreign-owner")
+    actual_uid = os.geteuid()
+    monkeypatch.setattr(runtime_security, "_validate_parent_chain", lambda path: None)
+    monkeypatch.setattr(runtime_security, "_effective_uid", lambda: actual_uid + 1)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError, match="untrusted"):
+        runtime_security.ensure_model_cache_directory(cache)
+
+
+@POSIX_ONLY
+@pytest.mark.parametrize("candidate_name", ["data", "workfolder", "repo", "cookies"])
+def test_model_cache_cannot_overlap_sensitive_runtime_roots(tmp_path, candidate_name):
+    repo = _make_safe_directory(tmp_path / "repo-cache-overlap")
+    data = repo / "data"
+    workfolder = repo / "workfolder"
+    cookies = data / "cookies"
+    logs = data / "logs"
+    candidates = {
+        "data": data,
+        "workfolder": workfolder,
+        "repo": repo,
+        "cookies": cookies,
+    }
+
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        runtime_security.validate_model_cache_location(
+            candidates[candidate_name],
+            private_roots=(data, workfolder),
+            protected_paths=(cookies, logs, data / "youdub.sqlite"),
+        )
+
+
+@POSIX_ONLY
+def test_unrelated_external_model_cache_is_not_recursively_changed(tmp_path):
+    repo = _make_safe_directory(tmp_path / "repo-external-cache")
+    data = repo / "data"
+    data.mkdir()
+    data.chmod(0o777)
+    external_cache = _make_safe_directory(tmp_path / "external-model-cache")
+    model_file = external_cache / "weights.bin"
+    model_file.write_bytes(b"synthetic-model")
+    model_file.chmod(0o644)
+
+    runtime_security.validate_model_cache_location(
+        external_cache,
+        private_roots=(data,),
+    )
+    runtime_security.migrate_private_runtime(
+        private_roots=(data,),
+        exclude_roots=(external_cache,),
+    )
+
+    assert _mode(data) == 0o700
+    assert _mode(external_cache) == 0o700
+    assert _mode(model_file) == 0o644
+
+
+@POSIX_ONLY
+@pytest.mark.parametrize("kind", ["symlink", "fifo", "hardlink"])
+def test_private_file_validation_rejects_links_and_special_files(tmp_path, kind):
+    root = _make_safe_directory(tmp_path / kind)
+    outside = root / "outside.txt"
+    outside.write_bytes(b"outside")
+    outside.chmod(0o640)
+    candidate = root / "candidate"
+    if kind == "symlink":
+        candidate.symlink_to(outside)
+    elif kind == "fifo":
+        os.mkfifo(candidate)
+    else:
+        os.link(outside, candidate)
+    outside_before = (outside.read_bytes(), _mode(outside), outside.stat().st_mtime_ns)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        runtime_security.secure_existing_file(candidate, required=True)
+
+    assert (outside.read_bytes(), _mode(outside), outside.stat().st_mtime_ns) == outside_before
+
+
+@POSIX_ONLY
+def test_private_directory_symlink_is_rejected_without_changing_target(tmp_path):
+    root = _make_safe_directory(tmp_path / "directory-link")
+    outside = root / "outside"
+    outside.mkdir()
+    outside.chmod(0o750)
+    linked = root / "data"
+    linked.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        runtime_security.ensure_private_directory(linked)
+
+    assert _mode(outside) == 0o750
+
+
+@POSIX_ONLY
+def test_sqlite_connect_and_live_wal_sidecars_are_private(monkeypatch, tmp_path):
+    root = _make_safe_directory(tmp_path / "sqlite")
+    db_path = root / "youdub.sqlite"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+
+    conn = database.connect()
+    try:
+        assert conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower() == "wal"
+        conn.execute("CREATE TABLE permission_probe (value TEXT)")
+        conn.execute("INSERT INTO permission_probe VALUES ('synthetic')")
+        conn.commit()
+        second = sqlite3.connect(db_path)
+        try:
+            second.execute("SELECT * FROM permission_probe").fetchall()
+            for path in (
+                db_path,
+                Path(f"{db_path}-wal"),
+                Path(f"{db_path}-shm"),
+            ):
+                assert path.exists()
+                assert _mode(path) == 0o600
+        finally:
+            second.close()
+    finally:
+        conn.close()
+
+
+@POSIX_ONLY
+def test_standalone_connect_secures_parent_and_database(monkeypatch, tmp_path):
+    db_path = tmp_path / "standalone" / "youdub.sqlite"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+
+    with database.connect() as conn:
+        conn.execute("CREATE TABLE permission_probe (value INTEGER)")
+
+    assert _mode(db_path.parent) == 0o700
+    assert _mode(db_path) == 0o600
+
+
+@POSIX_ONLY
+def test_concurrent_connect_does_not_race_transient_sqlite_sidecars(
+    monkeypatch, tmp_path
+):
+    root = _make_safe_directory(tmp_path / "sqlite-concurrent")
+    db_path = root / "youdub.sqlite"
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    with database.connect() as conn:
+        conn.execute("CREATE TABLE permission_probe (worker INTEGER, sequence INTEGER)")
+
+    def write_many(worker: int) -> list[runtime_security.RuntimeSecurityError]:
+        security_errors: list[runtime_security.RuntimeSecurityError] = []
+        for sequence in range(200):
+            try:
+                with database.connect() as conn:
+                    conn.execute("PRAGMA busy_timeout=30000")
+                    conn.execute(
+                        "INSERT INTO permission_probe VALUES (?, ?)",
+                        (worker, sequence),
+                    )
+            except runtime_security.RuntimeSecurityError as exc:
+                security_errors.append(exc)
+        return security_errors
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        worker_errors = list(executor.map(write_many, range(16)))
+
+    security_errors = [error for errors in worker_errors for error in errors]
+    assert security_errors == []
+
+    with database.connect() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM permission_probe").fetchone()[0]
+    assert count == 3200
+    assert _mode(root) == 0o700
+    assert _mode(db_path) == 0o600
+
+
+@POSIX_ONLY
+def test_production_connect_rejects_sidecar_symlink_before_sqlite(
+    monkeypatch, tmp_path
+):
+    repo = _make_safe_directory(tmp_path / "production-connect")
+    data = repo / "data"
+    data.mkdir()
+    db_path = data / "youdub.sqlite"
+    outside = repo / "outside-journal"
+    outside.write_bytes(b"outside")
+    Path(f"{db_path}-journal").symlink_to(outside)
+
+    monkeypatch.setattr(config, "REPO_ROOT", repo)
+    monkeypatch.setattr(config, "DATA_DIR", data)
+    monkeypatch.setattr(config, "COOKIE_DIR", data / "cookies")
+    monkeypatch.setattr(config, "WORKFOLDER", repo / "workfolder")
+    monkeypatch.setattr(config, "LOG_DIR", data / "logs")
+    monkeypatch.setattr(config, "MODEL_CACHE_DIR", data / "modelscope")
+    monkeypatch.setattr(config, "DB_PATH", db_path)
+    monkeypatch.setattr(config, "_RUNTIME_SECURITY_SIGNATURE", None)
+    monkeypatch.setattr(database, "DB_PATH", db_path)
+    connect_calls = []
+    monkeypatch.setattr(
+        database.sqlite3,
+        "connect",
+        lambda path: connect_calls.append(path),
+    )
+
+    with pytest.raises(runtime_security.RuntimeSecurityError, match="sidecar"):
+        database.connect()
+
+    assert connect_calls == []
+    assert outside.read_bytes() == b"outside"
+
+
+@POSIX_ONLY
+def test_sqlite_sidecar_disappearance_and_unlinked_fd_are_allowed(
+    monkeypatch, tmp_path
+):
+    root = _make_safe_directory(tmp_path / "sqlite-ephemeral-unit")
+    sidecar = root / "youdub.sqlite-journal"
+    real_open = os.open
+
+    sidecar.write_bytes(b"journal")
+
+    def disappear_before_open(path, flags, mode=0o777):
+        Path(path).unlink()
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr(runtime_security.os, "open", disappear_before_open)
+    assert runtime_security.secure_sqlite_sidecar_file(sidecar) is None
+
+    monkeypatch.setattr(runtime_security.os, "open", real_open)
+    sidecar.write_bytes(b"journal")
+
+    def unlink_after_open(path, flags, mode=0o777):
+        fd = real_open(path, flags, mode)
+        Path(path).unlink()
+        return fd
+
+    monkeypatch.setattr(runtime_security.os, "open", unlink_after_open)
+    metadata = runtime_security.secure_sqlite_sidecar_file(sidecar)
+
+    assert metadata is not None
+    assert metadata.st_nlink == 0
+
+
+@POSIX_ONLY
+def test_migration_tolerates_live_sqlite_journal_churn(tmp_path):
+    root = _make_safe_directory(tmp_path / "sqlite-migration-churn")
+    db_path = root / "youdub.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE permission_probe (value INTEGER)")
+    sidecars = runtime_security.sqlite_sidecar_paths(db_path)
+
+    def write_many() -> None:
+        with sqlite3.connect(db_path) as conn:
+            for value in range(2000):
+                conn.execute("INSERT INTO permission_probe VALUES (?)", (value,))
+                conn.commit()
+
+    def migrate_many() -> None:
+        for _ in range(400):
+            runtime_security.migrate_private_runtime(
+                private_roots=(root,),
+                ephemeral_files=sidecars,
+            )
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        writer = executor.submit(write_many)
+        migrator = executor.submit(migrate_many)
+        writer.result()
+        migrator.result()
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM permission_probe").fetchone()[0]
+    assert count == 2000
+
+
+@POSIX_ONLY
+def test_existing_sqlite_and_sidecar_modes_are_repaired_without_rewriting(tmp_path):
+    root = _make_safe_directory(tmp_path / "sqlite-existing")
+    db_path = root / "youdub.sqlite"
+    paths = (db_path, *runtime_security.sqlite_sidecar_paths(db_path))
+    before: dict[Path, tuple[bytes, int]] = {}
+    for index, path in enumerate(paths):
+        path.write_bytes(f"sidecar-{index}".encode())
+        path.chmod(0o666)
+        timestamp_ns = 1_700_000_100_000_000_000 + index
+        os.utime(path, ns=(timestamp_ns, timestamp_ns))
+        before[path] = (path.read_bytes(), path.stat().st_mtime_ns)
+
+    runtime_security.secure_sqlite_files(db_path)
+
+    for path, (content, mtime_ns) in before.items():
+        assert _mode(path) == 0o600
+        assert path.read_bytes() == content
+        assert path.stat().st_mtime_ns == mtime_ns
+
+
+@POSIX_ONLY
+def test_sqlite_sidecar_symlink_fails_closed(tmp_path):
+    root = _make_safe_directory(tmp_path / "sqlite-link")
+    db_path = root / "youdub.sqlite"
+    db_path.write_bytes(b"synthetic-db")
+    target = root / "outside"
+    target.write_bytes(b"outside")
+    target.chmod(0o640)
+    wal_path = Path(f"{db_path}-wal")
+    wal_path.symlink_to(target)
+    target_before = (target.read_bytes(), _mode(target), target.stat().st_mtime_ns)
+
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        runtime_security.secure_sqlite_files(db_path)
+
+    assert (target.read_bytes(), _mode(target), target.stat().st_mtime_ns) == target_before
+
+
+@POSIX_ONLY
+def test_atomic_private_cookie_write_and_symlink_rejection(tmp_path):
+    root = _make_safe_directory(tmp_path / "cookies")
+    cookie = root / "youtube.txt"
+    cookie.write_bytes(b"old")
+    cookie.chmod(0o666)
+
+    runtime_security.atomic_write_private_text(cookie, "new-cookie\n")
+
+    assert cookie.read_text() == "new-cookie\n"
+    assert _mode(cookie) == 0o600
+    assert not list(root.glob(".youtube.txt.*.tmp"))
+
+    outside = root / "outside"
+    outside.write_bytes(b"outside")
+    outside.chmod(0o640)
+    cookie.unlink()
+    cookie.symlink_to(outside)
+    target_before = (outside.read_bytes(), _mode(outside), outside.stat().st_mtime_ns)
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        runtime_security.atomic_write_private_text(cookie, "must-not-follow")
+    assert (outside.read_bytes(), _mode(outside), outside.stat().st_mtime_ns) == target_before
+
+
+@POSIX_ONLY
+def test_pipeline_log_is_private_append_and_rejects_symlink(monkeypatch, tmp_path):
+    log_dir = _make_safe_directory(tmp_path / "logs")
+    monkeypatch.setattr(config, "LOG_DIR", log_dir)
+
+    pipeline._write_log("task", "first")
+    pipeline._write_log("task", "second")
+
+    log_path = log_dir / "task.log"
+    assert _mode(log_path) == 0o600
+    assert "first" in log_path.read_text()
+    assert "second" in log_path.read_text()
+
+    outside = log_dir / "outside"
+    outside.write_bytes(b"outside")
+    log_path.unlink()
+    log_path.symlink_to(outside)
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        pipeline._write_log("task", "must-not-follow")
+    assert outside.read_bytes() == b"outside"
+
+
+@POSIX_ONLY
+def test_upload_is_private_exclusive_and_rejects_symlink(tmp_path):
+    root = _make_safe_directory(tmp_path / "uploads")
+    destination = root / "video.mp4"
+    upload = SimpleNamespace(file=BytesIO(b"video"))
+
+    assert main._save_uploaded_file(
+        upload,
+        destination,
+        max_bytes=100,
+        too_large_detail="too large",
+    ) == 5
+    assert destination.read_bytes() == b"video"
+    assert _mode(destination) == 0o600
+
+    destination.unlink()
+    outside = root / "outside"
+    outside.write_bytes(b"outside")
+    destination.symlink_to(outside)
+    upload = SimpleNamespace(file=BytesIO(b"replacement"))
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        main._save_uploaded_file(
+            upload,
+            destination,
+            max_bytes=100,
+            too_large_detail="too large",
+        )
+    assert outside.read_bytes() == b"outside"
+
+
+def test_runtime_security_interface_is_explicit():
+    assert runtime_security.RUNTIME_SECURITY_MODE in {
+        "posix-strong",
+        "windows-best-effort",
+    }
+
+
+def test_lifespan_permission_failure_does_not_start_worker(monkeypatch):
+    started = []
+
+    def fail_closed():
+        raise runtime_security.RuntimeSecurityError("unsafe runtime")
+
+    monkeypatch.setattr(main, "ensure_runtime_dirs", fail_closed)
+    monkeypatch.setattr(main.worker, "start", lambda runner: started.append(runner))
+
+    async def start_app():
+        async with main.lifespan(main.app):
+            pass
+
+    with pytest.raises(runtime_security.RuntimeSecurityError):
+        asyncio.run(start_app())
+    assert started == []


### PR DESCRIPTION
## 问题

运行目录和既有产物会继承较宽松的系统默认权限，Cookie、SQLite、日志、上传文件及生成产物可能被同机其他用户读取或替换；普通路径写入还存在符号链接跟随风险。

## 根因

- 进程没有统一设置私有 `umask`
- 启动时未迁移既有目录和文件的权限
- Cookie、日志和上传沿用普通路径写入，缺少 nofollow、独占创建和原子替换
- SQLite sidecar 与运行目录未统一做 owner、链接和特殊节点校验

## 修复

- POSIX 启动前永久设置 `umask 0077`，敏感目录收紧为 `0700`，普通敏感文件收紧为 `0600`
- dotenv 加载前校验仓库根和配置文件；仅兼容 `.env` 与 `env.txt` 的受控双硬链接，拒绝第三链接、符号链接、异主及特殊节点
- 启动时仅通过元数据迁移既有运行目录、SQLite 主库及 sidecar，不读取或改写文件内容
- Cookie 使用同目录私有临时文件原子替换，日志使用 nofollow 追加，上传使用 nofollow 独占创建
- 模型缓存根校验属主和祖先并隔离为 `0700`，缓存内部不递归修改；拒绝缓存路径覆盖敏感运行树
- 精确兼容 SQLite sidecar 的正常创建/删除竞态，普通敏感文件继续严格 fail closed
- 补充 POSIX/Windows 安全边界和首次迁移部署说明

## 验证

- `backend/tests/test_file_permissions.py`：36 项通过
- 后端全量：264 项通过，1 个既有 `pydub/audioop` 弃用警告
- 前端 ESLint：通过
- TypeScript `--noEmit`：通过
- Next.js 生产构建：通过
- `git diff --check`：通过
- 独立安全复核：无安全阻断，可合并

## 部署边界

- 首次权限迁移前应停止仍在创建或删除运行时文件的旧实例；迁移失败会阻止 worker 启动
- 模型缓存内部必须是预先可信内容
- Windows 仅提供兼容性检查，仍需管理员为服务账号配置正确的 NTFS DACL
