### PR TITLE
修复 SQLite sidecar 删除竞态

### DIFF
--- a/backend/app/runtime_security.py
+++ b/backend/app/runtime_security.py
@@ -465,9 +465,11 @@ def secure_sqlite_sidecar_file(path: Path | str) -> os.stat_result | None:
         _validate_sqlite_sidecar_metadata(
             target,
             metadata,
-            allow_unlinked=False,
+            allow_unlinked=True,
         )
         if not POSIX_STRONG_PERMISSIONS:
+            return metadata
+        if metadata.st_nlink == 0:
             return metadata
 
         try:

--- a/backend/tests/test_file_permissions.py
+++ b/backend/tests/test_file_permissions.py
@@ -493,13 +493,36 @@ def test_sqlite_sidecar_disappearance_and_unlinked_fd_are_allowed(
     root = _make_safe_directory(tmp_path / "sqlite-ephemeral-unit")
     sidecar = root / "youdub.sqlite-journal"
     real_open = os.open
+    real_lstat = os.lstat
 
     sidecar.write_bytes(b"journal")
+    unlinked_values = list(real_lstat(sidecar))
+    unlinked_values[3] = 0
+    unlinked_metadata = os.stat_result(unlinked_values)
+    open_calls = []
+
+    def lstat_after_sqlite_unlink(path):
+        if Path(path) == sidecar:
+            return unlinked_metadata
+        return real_lstat(path)
+
+    monkeypatch.setattr(runtime_security.os, "lstat", lstat_after_sqlite_unlink)
+    monkeypatch.setattr(
+        runtime_security.os,
+        "open",
+        lambda *args, **kwargs: open_calls.append(args),
+    )
+    metadata = runtime_security.secure_sqlite_sidecar_file(sidecar)
+
+    assert metadata is not None
+    assert metadata.st_nlink == 0
+    assert open_calls == []
 
     def disappear_before_open(path, flags, mode=0o777):
         Path(path).unlink()
         raise FileNotFoundError(path)
 
+    monkeypatch.setattr(runtime_security.os, "lstat", real_lstat)
     monkeypatch.setattr(runtime_security.os, "open", disappear_before_open)
     assert runtime_security.secure_sqlite_sidecar_file(sidecar) is None
 


### PR DESCRIPTION
## 问题

权限迁移与 SQLite 提交并发时，`lstat` 可能拿到一个刚被 SQLite 删除、链接数已变成 0 的 journal 元数据。现有校验会把这个合法瞬时状态误判为硬链接攻击，导致新实例 fail closed 启动失败。

## 根因

SQLite 的 DELETE journal 会在提交后立即 unlink。文件系统竞态下，`lstat` 返回的节点仍是合法普通文件，但 `st_nlink` 已经是 0；原校验只在 open 后允许该状态，遗漏了初始 `lstat` 已观察到 unlink 的情况。

## 修复

- 仅在精确 SQLite sidecar 校验器中允许已通过 regular file、属主和 nofollow 检查的 `nlink=0`
- 该状态直接按“SQLite 已完成删除”处理，不再尝试打开路径
- `nlink>1`、符号链接、FIFO、特殊文件、异主节点以及普通敏感文件仍严格拒绝
- 补充初始 `lstat` 返回 `nlink=0` 的确定性回归测试

## 验证

- SQLite journal churn 压力用例连续 5 次通过
- 权限专项：36 项通过
- 后端全量：264 项通过，1 个既有 `pydub/audioop` 弃用警告
- `git diff --check`：通过
- 独立安全复核：无阻断，可合并
