### PR TITLE
安全：严格校验视频来源 URL

### DIFF
--- a/backend/app/adapters/ytdlp.py
+++ b/backend/app/adapters/ytdlp.py
@@ -13,7 +13,7 @@ import yt_dlp
 from .. import runtime_security
 from ..sanitize import sanitize_text
 from ..sources import SourceConfig
-from ..youtube import extract_video_id
+from ..youtube import extract_video_id, validate_video_url
 
 
 FORMAT_CANDIDATES = (
@@ -131,11 +131,15 @@ def _download_with_format_candidates(
 def download_video(
     url: str, workfolder: Path, source: SourceConfig, proxy_port: str = ""
 ) -> tuple[Path, dict[str, Any]]:
-    video_id = extract_video_id(url)
+    validated = validate_video_url(url)
+    if validated.source != source.name:
+        raise ValueError("The submitted URL does not match the selected video source.")
+    canonical_url = validated.url
+    video_id = validated.video_id
     _ensure_cookie(source)
     info_opts = _ydl_base(source, proxy_port)
     with yt_dlp.YoutubeDL(info_opts) as ydl:
-        info = ydl.extract_info(url, download=False)
+        info = ydl.extract_info(canonical_url, download=False)
 
     if str(info.get("id", video_id)) != video_id:
         raise ValueError("The resolved video id does not match the submitted URL.")
@@ -153,7 +157,7 @@ def download_video(
     if video_file.exists() and video_file.stat().st_size > 0:
         return session, info
 
-    _download_with_format_candidates(url, video_file, source, proxy_port)
+    _download_with_format_candidates(canonical_url, video_file, source, proxy_port)
 
     if not video_file.exists() or video_file.stat().st_size == 0:
         raise RuntimeError("yt-dlp finished without producing media/video_source.mp4")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,7 +27,7 @@ from .sanitize import sanitize_text
 from .sources import detect_source
 from .stage_reset import remove_stage_artifacts
 from .stages import STAGE_NAMES
-from .youtube import LOCAL_UPLOAD_DIRECTIONS, extract_video_id, is_local_upload_url
+from .youtube import LOCAL_UPLOAD_DIRECTIONS, is_local_upload_url, validate_video_url
 
 ALLOWED_VIDEO_SUFFIXES = {".mp4", ".mov", ".m4v", ".mkv", ".webm", ".avi", ".flv", ".wmv"}
 ALLOWED_SUBTITLE_SUFFIXES = {".srt"}
@@ -321,18 +321,18 @@ def normalize_execution_mode(value: str) -> str:
 @app.post("/api/tasks", status_code=201)
 def create_task(payload: TaskCreate) -> dict:
     try:
-        video_id = extract_video_id(payload.url)
+        validated_url = validate_video_url(payload.url)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    existing_id = database.find_task_by_video_id(video_id)
+    existing_id = database.find_task_by_video_id(validated_url.video_id)
     if existing_id:
         return database.get_task(existing_id)
 
     _ensure_runtime_ready()
     task_id = database.create_task(
-        payload.url.strip(),
-        task_id=video_id,
+        validated_url.url,
+        task_id=validated_url.video_id,
         execution_mode=normalize_execution_mode(payload.execution_mode),
     )
     worker.enqueue(task_id)

--- a/backend/app/youtube.py
+++ b/backend/app/youtube.py
@@ -1,68 +1,135 @@
 from __future__ import annotations
 
 import re
-from urllib.parse import parse_qs, urlparse
+from dataclasses import dataclass
+from urllib.parse import SplitResult, parse_qs, urlparse, urlsplit, urlunsplit
 
 
 YOUTUBE_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
 BILIBILI_BV_RE = re.compile(r"BV[A-Za-z0-9]{10}")
-BILIBILI_HOSTS = {"bilibili.com", "www.bilibili.com", "m.bilibili.com"}
+REMOTE_URL_UNSAFE_RE = re.compile(r"[\\\x00-\x20\x7f]")
+YOUTUBE_LONG_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com"}
+YOUTUBE_SHORT_HOSTS = {"youtu.be"}
+BILIBILI_HOSTS = {"bilibili.com", "www.bilibili.com"}
+DEFAULT_HTTP_PORTS = {"http": 80, "https": 443}
 LOCAL_UPLOAD_SCHEME = "local"
 LOCAL_UPLOAD_HOST = "upload"
 LOCAL_UPLOAD_DIRECTIONS = {"en-zh", "zh-en"}
 LOCAL_UPLOAD_TASK_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
-def _extract_youtube_id(parsed) -> str | None:
-    host = parsed.netloc.lower()
-    path = parsed.path.strip("/")
+@dataclass(frozen=True)
+class ValidatedVideoURL:
+    source: str
+    video_id: str
+    url: str
 
-    if host in {"youtu.be", "www.youtu.be"}:
-        candidate = path.split("/")[0]
-        if YOUTUBE_ID_RE.match(candidate):
-            return candidate
 
-    if "youtube.com" not in host:
+def _parse_remote_video_url(url: str) -> tuple[SplitResult, str] | None:
+    candidate = url.strip()
+    if not candidate or REMOTE_URL_UNSAFE_RE.search(candidate):
+        return None
+    try:
+        parsed = urlsplit(candidate)
+        hostname = parsed.hostname
+        port = parsed.port
+        username = parsed.username
+        password = parsed.password
+    except (TypeError, ValueError):
         return None
 
-    query_id = parse_qs(parsed.query).get("v", [""])[0]
-    if YOUTUBE_ID_RE.match(query_id):
-        return query_id
+    scheme = parsed.scheme.lower()
+    if scheme not in DEFAULT_HTTP_PORTS or not hostname:
+        return None
+    if username is not None or password is not None:
+        return None
+    if parsed.netloc.endswith(":"):
+        return None
+    if port is not None and port != DEFAULT_HTTP_PORTS[scheme]:
+        return None
+    return parsed, hostname.lower()
 
-    parts = path.split("/")
-    for prefix in ("shorts", "embed", "live"):
-        if len(parts) >= 2 and parts[0] == prefix and YOUTUBE_ID_RE.match(parts[1]):
-            return parts[1]
+
+def _extract_youtube_video(
+    parsed: SplitResult, host: str
+) -> tuple[str, str, str] | None:
+    path = parsed.path.strip("/")
+    parts = path.split("/") if path else []
+
+    if host in YOUTUBE_SHORT_HOSTS:
+        candidate = parts[0] if len(parts) == 1 else ""
+        if YOUTUBE_ID_RE.match(candidate):
+            return candidate, f"/{candidate}", ""
+        return None
+
+    if host not in YOUTUBE_LONG_HOSTS:
+        return None
+
+    if parts == ["watch"]:
+        query_id = parse_qs(parsed.query).get("v", [""])[0]
+        if YOUTUBE_ID_RE.match(query_id):
+            return query_id, "/watch", f"v={query_id}"
+
+    if (
+        len(parts) == 2
+        and parts[0] in {"shorts", "embed", "live"}
+        and YOUTUBE_ID_RE.match(parts[1])
+    ):
+        return parts[1], f"/{parts[0]}/{parts[1]}", ""
     return None
 
 
-def _extract_bilibili_id(parsed) -> str | None:
-    host = parsed.netloc.lower()
+def _extract_bilibili_video(
+    parsed: SplitResult, host: str
+) -> tuple[str, str, str] | None:
     if host not in BILIBILI_HOSTS:
         return None
-    match = BILIBILI_BV_RE.search(parsed.path)
-    if match:
-        return match.group(0)
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) == 2 and parts[0] == "video" and BILIBILI_BV_RE.fullmatch(parts[1]):
+        return parts[1], f"/video/{parts[1]}", ""
     return None
+
+
+def validate_video_url(url: str) -> ValidatedVideoURL:
+    parsed_host = _parse_remote_video_url(url)
+    if parsed_host is not None:
+        parsed, host = parsed_host
+        video = _extract_youtube_video(parsed, host)
+        source = "youtube"
+        if video is None:
+            video = _extract_bilibili_video(parsed, host)
+            source = "bilibili"
+        if video is not None:
+            video_id, canonical_path, canonical_query = video
+            canonical_url = urlunsplit(
+                (
+                    parsed.scheme.lower(),
+                    host,
+                    canonical_path,
+                    canonical_query,
+                    "",
+                )
+            )
+            return ValidatedVideoURL(source=source, video_id=video_id, url=canonical_url)
+    raise ValueError("Only YouTube or Bilibili single-video URLs are supported.")
 
 
 def extract_video_id(url: str) -> str:
-    parsed = urlparse(url.strip())
-    video_id = _extract_youtube_id(parsed) or _extract_bilibili_id(parsed)
-    if video_id:
-        return video_id
-    raise ValueError("Only YouTube or Bilibili single-video URLs are supported.")
+    return validate_video_url(url).video_id
 
 
 def is_youtube_url(url: str) -> bool:
     try:
-        return _extract_youtube_id(urlparse(url.strip())) is not None
+        return validate_video_url(url).source == "youtube"
     except ValueError:
         return False
 
 
 def is_bilibili_url(url: str) -> bool:
-    return urlparse(url.strip()).netloc.lower() in BILIBILI_HOSTS
+    try:
+        return validate_video_url(url).source == "bilibili"
+    except ValueError:
+        return False
 
 
 def local_upload_task_id(url: str) -> str:

--- a/backend/tests/test_settings_and_api.py
+++ b/backend/tests/test_settings_and_api.py
@@ -173,6 +173,24 @@ def test_different_videos_create_separate_tasks(monkeypatch, tmp_path):
     assert enqueued == ["abcdefghijk", "zyxwvutsrqp"]
 
 
+def test_deceptive_video_host_is_rejected_without_task_or_enqueue(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    enqueued: list[str] = []
+    monkeypatch.setattr(main.worker, "enqueue", lambda task_id: enqueued.append(task_id))
+    client = authenticated_client()
+
+    response = client.post(
+        "/api/tasks",
+        json={
+            "url": "https://youtube.com.evil.example/watch?v=abcdefghijk"
+        },
+    )
+
+    assert response.status_code == 422
+    assert database.list_tasks() == []
+    assert enqueued == []
+
+
 def make_history_task(
     task_id: str,
     *,

--- a/backend/tests/test_youtube.py
+++ b/backend/tests/test_youtube.py
@@ -1,4 +1,6 @@
 import pytest
+from yt_dlp.extractor.bilibili import BiliBiliIE
+from yt_dlp.extractor.youtube import YoutubeIE
 
 from backend.app.youtube import (
     extract_video_id,
@@ -9,6 +11,7 @@ from backend.app.youtube import (
     is_youtube_url,
     local_upload_direction,
     local_upload_task_id,
+    validate_video_url,
 )
 
 
@@ -20,12 +23,118 @@ def test_extract_video_id_from_shorts_url():
     assert extract_video_id("https://youtube.com/shorts/abcdefghijk?feature=share") == "abcdefghijk"
 
 
+@pytest.mark.parametrize(
+    ("url", "expected_id", "expected_url"),
+    [
+        (
+            "HTTPS://YOUTUBE.COM:443/watch?v=abcdefghijk",
+            "abcdefghijk",
+            "https://youtube.com/watch?v=abcdefghijk",
+        ),
+        (
+            "https://WWW.YOUTUBE.COM/embed/abcdefghijk",
+            "abcdefghijk",
+            "https://www.youtube.com/embed/abcdefghijk",
+        ),
+        (
+            "http://M.YOUTUBE.COM:80/live/abcdefghijk",
+            "abcdefghijk",
+            "http://m.youtube.com/live/abcdefghijk",
+        ),
+        (
+            "https://youtu.be/abcdefghijk",
+            "abcdefghijk",
+            "https://youtu.be/abcdefghijk",
+        ),
+        (
+            "https://youtube.com//watch//?%76=%61bcdefghijk&t=12s#ignored",
+            "abcdefghijk",
+            "https://youtube.com/watch?v=abcdefghijk",
+        ),
+        (
+            "https://youtu.be//abcdefghijk//?feature=share#ignored",
+            "abcdefghijk",
+            "https://youtu.be/abcdefghijk",
+        ),
+    ],
+)
+def test_youtube_url_accepts_only_explicit_supported_hosts(
+    url, expected_id, expected_url
+):
+    validated = validate_video_url(url)
+
+    assert validated.source == "youtube"
+    assert validated.video_id == expected_id
+    assert validated.url == expected_url
+    assert YoutubeIE.suitable(validated.url)
+    assert is_youtube_url(url)
+    assert extract_video_id(url) == expected_id
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://youtube.com/watch?v=abcdefghijk",
+        "//youtube.com/watch?v=abcdefghijk",
+        "https://notyoutube.com/watch?v=abcdefghijk",
+        "https://youtube.com.evil.example/watch?v=abcdefghijk",
+        "https://youtube.com@evil.example/watch?v=abcdefghijk",
+        "https://evil.example@youtube.com/watch?v=abcdefghijk",
+        "https://user:password@youtube.com/watch?v=abcdefghijk",
+        "https://youtube.com:444/watch?v=abcdefghijk",
+        "http://youtube.com:443/watch?v=abcdefghijk",
+        "https://youtube.com:99999/watch?v=abcdefghijk",
+        "https://youtube.com:not-a-port/watch?v=abcdefghijk",
+        "https://youtube.com:/watch?v=abcdefghijk",
+        "https://youtube.com./watch?v=abcdefghijk",
+        "https://music.youtube.com/watch?v=abcdefghijk",
+        "https://evil.example/youtube.com/watch?v=abcdefghijk",
+        "https://youtube.com\\@evil.example/watch?v=abcdefghijk",
+        "https://youtube.com/redirect?q=http://127.0.0.1/&v=abcdefghijk",
+        "https://youtube.com/anything?v=abcdefghijk",
+        "https://youtu.be/abcdefghijk/extra",
+        "https://youtubе.com/watch?v=abcdefghijk",
+        "https://youtube.com/watch?v=abcdefghijk\nHost: evil.example",
+    ],
+)
+def test_youtube_url_rejects_deceptive_hosts_schemes_userinfo_and_ports(url):
+    assert not is_youtube_url(url)
+    with pytest.raises(ValueError):
+        extract_video_id(url)
+
+
 def test_rejects_playlist_only_url():
     assert not is_youtube_url("https://www.youtube.com/playlist?list=123")
 
 
 def test_extract_video_id_from_bilibili_url():
     assert extract_video_id("https://www.bilibili.com/video/BV1xx411c7mD/?spm_id_from=test") == "BV1xx411c7mD"
+
+
+def test_bilibili_url_is_canonicalized_to_the_expected_extractor():
+    validated = validate_video_url(
+        "HTTPS://WWW.BILIBILI.COM:443//video/BV1xx411c7mD//?spm_id_from=test"
+    )
+
+    assert validated.source == "bilibili"
+    assert validated.video_id == "BV1xx411c7mD"
+    assert validated.url == "https://www.bilibili.com/video/BV1xx411c7mD"
+    assert BiliBiliIE.suitable(validated.url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://www.bilibili.com/video/BV1xx411c7mD",
+        "https://www.bilibili.com/redirect/BV1xx411c7mD",
+        "https://www.bilibili.com/anything?v=BV1xx411c7mD",
+        "https://m.bilibili.com/video/BV1xx411c7mD",
+    ],
+)
+def test_bilibili_url_rejects_non_video_generic_extractor_fallbacks(url):
+    assert not is_bilibili_url(url)
+    with pytest.raises(ValueError):
+        extract_video_id(url)
 
 
 def test_is_bilibili_url():

--- a/backend/tests/test_ytdlp.py
+++ b/backend/tests/test_ytdlp.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from backend.app.adapters import ytdlp
 from backend.app.sources import SourceConfig
 
@@ -60,3 +62,82 @@ def test_ytdlp_enables_node_js_runtime(tmp_path):
 def test_ytdlp_format_candidates_start_with_backend_format():
     assert ytdlp.FORMAT_CANDIDATES[0] == "bestvideo[height<=1080]+bestaudio/best"
     assert "bestvideo[height<=1080]+bestaudio/best[height<=1080]/best" not in ytdlp.FORMAT_CANDIDATES
+
+
+def _youtube_source() -> SourceConfig:
+    return SourceConfig(
+        name="youtube",
+        matches=lambda url: True,
+        use_proxy=False,
+        cookie_filename=None,
+        asr_language="en",
+        target_language="zh",
+    )
+
+
+def test_download_video_passes_only_the_canonical_url_to_both_ytdlp_sinks(
+    monkeypatch, tmp_path
+):
+    extracted_urls: list[str] = []
+    downloaded_urls: list[str] = []
+
+    class FakeYoutubeDL:
+        def __init__(self, options):
+            self.options = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def extract_info(self, url, *, download):
+            extracted_urls.append(url)
+            assert download is False
+            return {
+                "id": "abcdefghijk",
+                "uploader": "tester",
+                "title": "canonical",
+                "webpage_url": url,
+            }
+
+        def sanitize_info(self, info):
+            return info
+
+        def download(self, urls):
+            downloaded_urls.extend(urls)
+            Path(self.options["outtmpl"]).write_bytes(b"video")
+
+    monkeypatch.setattr(ytdlp.yt_dlp, "YoutubeDL", FakeYoutubeDL)
+
+    session, _ = ytdlp.download_video(
+        "HTTPS://WWW.YOUTUBE.COM:443/watch?v=abcdefghijk",
+        tmp_path,
+        _youtube_source(),
+    )
+
+    expected = "https://www.youtube.com/watch?v=abcdefghijk"
+    assert extracted_urls == [expected]
+    assert downloaded_urls == [expected]
+    assert (session / "media" / "video_source.mp4").read_bytes() == b"video"
+
+
+def test_download_video_rejects_deceptive_url_before_cookie_or_ytdlp(
+    monkeypatch, tmp_path
+):
+    calls: list[str] = []
+    monkeypatch.setattr(ytdlp, "_ensure_cookie", lambda source: calls.append("cookie"))
+    monkeypatch.setattr(
+        ytdlp.yt_dlp,
+        "YoutubeDL",
+        lambda options: calls.append("ytdlp"),
+    )
+
+    with pytest.raises(ValueError):
+        ytdlp.download_video(
+            "https://youtube.com.evil.example/watch?v=abcdefghijk",
+            tmp_path,
+            _youtube_source(),
+        )
+
+    assert calls == []


### PR DESCRIPTION
## 问题

YouTube URL 使用 `"youtube.com" in netloc` 判断，导致伪装域名、userinfo、异常端口及非 HTTP(S) 地址可通过校验并进入 yt-dlp。任意域内路径还可能让 yt-dlp 回落到 GenericIE，跟随开放重定向形成新的请求绕过。

## 根因

- 未使用解析后的 `hostname` 做精确白名单匹配
- 未统一限制协议、userinfo 和端口
- 校验后的原始字符串直接传给 yt-dlp，应用解析器与 yt-dlp extractor 存在差异
- 只检查视频 ID，没有限制目标 extractor 支持的单视频路径形状

## 修复

- 新增统一视频 URL 校验器，返回来源、视频 ID 和 canonical URL
- 仅允许 HTTP(S)、无 userinfo、显式主机白名单及同协议默认端口
- YouTube 仅接受 `youtube.com`、`www.youtube.com`、`m.youtube.com`、`youtu.be` 的标准单视频路径
- Bilibili 仅接受 `bilibili.com`、`www.bilibili.com` 的 `/video/{BV}` 路径，阻止 GenericIE fallback
- 去除默认端口、大小写差异、多余斜杠、tracking 参数和 fragment，重建只含标准路径与视频 ID 的 canonical URL
- API 只保存 canonical URL；下载前再次校验来源，`extract_info` 和 `download` 两个 sink 都只接收 canonical URL

## 验证

- URL、yt-dlp sink 和 API 专项：116 项通过
- 后端全量：299 项通过，1 个既有 `pydub/audioop` 弃用警告
- 额外独立攻击矩阵：47 项通过
- 非法端口等 API 输入：均返回 422，0 task、0 enqueue
- `git diff --check`：通过
- 独立安全复核：无阻断，可合并

## 兼容性说明

`m.bilibili.com` 与 `www.youtu.be` 不会命中当前目标 yt-dlp extractor，因此改为明确拒绝；tracking 参数与 fragment 不参与下载，会在 canonical 化时丢弃。
