### PR TITLE
修复上传 SRT 的阶段重做

### DIFF
--- a/backend/app/adapters/local_subtitles.py
+++ b/backend/app/adapters/local_subtitles.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .. import runtime_security
 from ..sources import SourceConfig
 from .local_video import upload_dir
 
@@ -97,13 +98,10 @@ def _translation_items(cues: list[SubtitleCue], source: SourceConfig) -> list[di
     ]
 
 
-def write_uploaded_subtitle_artifacts(
+def _uploaded_subtitle_payloads(
     subtitle_file: Path,
-    session: Path,
     source: SourceConfig,
-) -> tuple[Path, Path, Path]:
-    metadata_dir = session / "metadata"
-    metadata_dir.mkdir(parents=True, exist_ok=True)
+) -> tuple[dict[str, Any], dict[str, Any]]:
     content = subtitle_file.read_text(encoding="utf-8-sig")
     cues = parse_srt(content)
     translation = _translation_items(cues, source)
@@ -124,14 +122,59 @@ def write_uploaded_subtitle_artifacts(
         }
     }
     translation_payload = {"translation": translation}
+    return asr_payload, translation_payload
 
+
+def _write_json_artifact(path: Path, payload: dict[str, Any]) -> Path:
+    content = json.dumps(payload, ensure_ascii=False, indent=2)
+    runtime_security.atomic_write_private_text(path, content)
+    return path
+
+
+def write_uploaded_asr_artifact(
+    subtitle_file: Path,
+    session: Path,
+    source: SourceConfig,
+) -> Path:
+    asr_payload, _ = _uploaded_subtitle_payloads(subtitle_file, source)
+    return _write_json_artifact(session / "metadata" / "asr.json", asr_payload)
+
+
+def write_uploaded_asr_fixed_artifact(
+    subtitle_file: Path,
+    session: Path,
+    source: SourceConfig,
+) -> Path:
+    asr_payload, _ = _uploaded_subtitle_payloads(subtitle_file, source)
+    return _write_json_artifact(session / "metadata" / "asr_fixed.json", asr_payload)
+
+
+def write_uploaded_translation_artifact(
+    subtitle_file: Path,
+    session: Path,
+    source: SourceConfig,
+) -> Path:
+    _, translation_payload = _uploaded_subtitle_payloads(subtitle_file, source)
+    return _write_json_artifact(
+        session / "metadata" / f"translation.{source.target_language}.json",
+        translation_payload,
+    )
+
+
+def write_uploaded_subtitle_artifacts(
+    subtitle_file: Path,
+    session: Path,
+    source: SourceConfig,
+) -> tuple[Path, Path, Path]:
+    asr_payload, translation_payload = _uploaded_subtitle_payloads(
+        subtitle_file, source
+    )
+
+    metadata_dir = session / "metadata"
     asr_file = metadata_dir / "asr.json"
     asr_fixed_file = metadata_dir / "asr_fixed.json"
     translation_file = metadata_dir / f"translation.{source.target_language}.json"
-    asr_file.write_text(json.dumps(asr_payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    asr_fixed_file.write_text(json.dumps(asr_payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    translation_file.write_text(
-        json.dumps(translation_payload, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
+    _write_json_artifact(asr_file, asr_payload)
+    _write_json_artifact(asr_fixed_file, asr_payload)
+    _write_json_artifact(translation_file, translation_payload)
     return asr_file, asr_fixed_file, translation_file

--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -180,15 +180,15 @@ class PipelineRunner:
             return None
         return _require_existing(Path(subtitle_path), "uploaded_subtitle_file")
 
-    def _write_uploaded_subtitle_artifacts(self, task: dict) -> tuple[Path, Path, Path]:
-        from .adapters.local_subtitles import write_uploaded_subtitle_artifacts
+    def _write_uploaded_asr_artifact(self, task: dict) -> Path:
+        from .adapters.local_subtitles import write_uploaded_asr_artifact
 
         session = _require(self.artifacts.session, "session")
         subtitle_file = self._uploaded_subtitle_path(task)
         if not subtitle_file:
             raise RuntimeError("Missing uploaded subtitle file.")
         source = detect_source(task["url"])
-        return write_uploaded_subtitle_artifacts(subtitle_file, session, source)
+        return write_uploaded_asr_artifact(subtitle_file, session, source)
 
     def _run_stage(self, stage: str) -> None:
         self._progress_state.pop(stage, None)
@@ -294,14 +294,13 @@ class PipelineRunner:
         session = _require(self.artifacts.session, "session")
         subtitle_file = self._uploaded_subtitle_path(task)
         if subtitle_file:
-            asr_file, asr_fixed_file, translation_file = self._write_uploaded_subtitle_artifacts(task)
-            self.artifacts.asr_file = asr_file
-            self.artifacts.asr_fixed_file = asr_fixed_file
-            self.artifacts.translation_file = translation_file
-            items = _json.loads(translation_file.read_text(encoding="utf-8"))["translation"]
+            self.artifacts.asr_file = self._write_uploaded_asr_artifact(task)
+            items = _json.loads(
+                self.artifacts.asr_file.read_text(encoding="utf-8")
+            )["result"]["utterances"]
             self.stage_message(
                 "asr",
-                f"Used uploaded SRT subtitles ({len(items)} cues) -> {asr_file.name}; skipped Whisper",
+                f"Used uploaded SRT subtitles ({len(items)} cues) -> {self.artifacts.asr_file.name}; skipped Whisper",
             )
             return
 
@@ -322,10 +321,15 @@ class PipelineRunner:
         import json as _json
 
         session = _require(self.artifacts.session, "session")
-        if self._uploaded_subtitle_path(task):
-            self.artifacts.asr_fixed_file = _require_existing(
-                session / "metadata" / "asr_fixed.json",
-                "asr_fixed_file",
+        subtitle_file = self._uploaded_subtitle_path(task)
+        if subtitle_file:
+            from .adapters.local_subtitles import write_uploaded_asr_fixed_artifact
+
+            source = detect_source(task["url"])
+            self.artifacts.asr_fixed_file = write_uploaded_asr_fixed_artifact(
+                subtitle_file,
+                session,
+                source,
             )
             sentences = _json.loads(
                 self.artifacts.asr_fixed_file.read_text(encoding="utf-8")
@@ -353,10 +357,14 @@ class PipelineRunner:
 
         session = _require(self.artifacts.session, "session")
         source = detect_source(task["url"])
-        if self._uploaded_subtitle_path(task):
-            self.artifacts.translation_file = _require_existing(
-                session / "metadata" / f"translation.{source.target_language}.json",
-                "translation_file",
+        subtitle_file = self._uploaded_subtitle_path(task)
+        if subtitle_file:
+            from .adapters.local_subtitles import write_uploaded_translation_artifact
+
+            self.artifacts.translation_file = write_uploaded_translation_artifact(
+                subtitle_file,
+                session,
+                source,
             )
             items = _json.loads(
                 self.artifacts.translation_file.read_text(encoding="utf-8")

--- a/backend/tests/test_local_subtitles.py
+++ b/backend/tests/test_local_subtitles.py
@@ -73,6 +73,80 @@ def test_write_uploaded_subtitle_artifacts_outputs_pipeline_schema(tmp_path):
     }
 
 
+@pytest.mark.parametrize(
+    ("writer_name", "target_name"),
+    [
+        ("write_uploaded_asr_artifact", "asr.json"),
+        ("write_uploaded_asr_fixed_artifact", "asr_fixed.json"),
+        ("write_uploaded_translation_artifact", "translation.zh.json"),
+    ],
+)
+def test_uploaded_subtitle_stage_writer_only_replaces_its_own_artifact(
+    tmp_path, writer_name, target_name
+):
+    subtitle = tmp_path / "subtitles.srt"
+    subtitle.write_text(
+        "1\n00:00:00,000 --> 00:00:01,200\n你好世界\n",
+        encoding="utf-8",
+    )
+    subtitle_before = subtitle.read_bytes()
+    metadata = tmp_path / "metadata"
+    metadata.mkdir()
+    artifact_names = ("asr.json", "asr_fixed.json", "translation.zh.json")
+    sentinels = {name: f"sentinel:{name}".encode() for name in artifact_names}
+    for name, content in sentinels.items():
+        (metadata / name).write_bytes(content)
+
+    writer = getattr(local_subtitles, writer_name)
+    output = writer(
+        subtitle,
+        tmp_path,
+        detect_source("local://upload/task-id?direction=en-zh"),
+    )
+
+    assert output == metadata / target_name
+    assert subtitle.read_bytes() == subtitle_before
+    for name, content in sentinels.items():
+        if name == target_name:
+            assert (metadata / name).read_bytes() != content
+        else:
+            assert (metadata / name).read_bytes() == content
+
+
+@pytest.mark.parametrize(
+    "writer_name",
+    [
+        "write_uploaded_asr_artifact",
+        "write_uploaded_asr_fixed_artifact",
+        "write_uploaded_translation_artifact",
+    ],
+)
+def test_uploaded_subtitle_stage_writer_failure_preserves_all_artifacts(
+    tmp_path, writer_name
+):
+    subtitle = tmp_path / "invalid.srt"
+    subtitle.write_text("invalid subtitle", encoding="utf-8")
+    subtitle_before = subtitle.read_bytes()
+    metadata = tmp_path / "metadata"
+    metadata.mkdir()
+    artifact_names = ("asr.json", "asr_fixed.json", "translation.zh.json")
+    sentinels = {name: f"sentinel:{name}".encode() for name in artifact_names}
+    for name, content in sentinels.items():
+        (metadata / name).write_bytes(content)
+
+    writer = getattr(local_subtitles, writer_name)
+    with pytest.raises(ValueError):
+        writer(
+            subtitle,
+            tmp_path,
+            detect_source("local://upload/task-id?direction=en-zh"),
+        )
+
+    assert subtitle.read_bytes() == subtitle_before
+    for name, content in sentinels.items():
+        assert (metadata / name).read_bytes() == content
+
+
 def test_split_audio_by_uploaded_subtitle_translation(monkeypatch, tmp_path):
     translation = tmp_path / "metadata" / "translation.zh.json"
     translation.parent.mkdir()

--- a/backend/tests/test_settings_and_api.py
+++ b/backend/tests/test_settings_and_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import sqlite3
 import threading
@@ -7,9 +8,10 @@ import threading
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.app import auth, config, database
+from backend.app import auth, config, database, pipeline
 from backend.app import main
 from backend.app import worker
+from backend.app.adapters import local_subtitles
 from backend.tests.conftest import TEST_AUTH_PASSWORD
 
 
@@ -1043,6 +1045,103 @@ def test_redo_stage_requeues_manual_task(monkeypatch, tmp_path):
     assert translate_stage["status"] == "pending"
     assert split_stage["status"] == "pending"
     assert enqueued == [task_id]
+
+
+@pytest.mark.parametrize(
+    ("stage_name", "upstream_name", "generated_name"),
+    [
+        ("asr_fix", "asr.json", "asr_fixed.json"),
+        ("translate", "asr_fixed.json", "translation.zh.json"),
+    ],
+)
+def test_uploaded_srt_stage_redo_regenerates_from_original_subtitle(
+    monkeypatch,
+    tmp_path,
+    stage_name,
+    upstream_name,
+    generated_name,
+):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    workfolder = main.WORKFOLDER
+    monkeypatch.setattr(pipeline, "WORKFOLDER", workfolder)
+    monkeypatch.setattr(main, "validate_runtime_device", lambda: None)
+    monkeypatch.setattr(pipeline, "validate_runtime_device", lambda: None)
+    monkeypatch.setattr(pipeline, "device_plan_summary", lambda: "test-device")
+
+    task_id = f"uploaded-srt-redo-{stage_name}"
+    task_url = f"local://upload/{task_id}?direction=en-zh&filename=clip.mp4"
+    subtitle_dir = local_subtitles.uploaded_subtitle_dir(workfolder, task_id)
+    subtitle_dir.mkdir(parents=True)
+    subtitle_file = subtitle_dir / "clip.zh.srt"
+    subtitle_file.write_text(
+        "1\n00:00:00,000 --> 00:00:01,000\n你好\n\n"
+        "2\n00:00:01,200 --> 00:00:02,000\n世界\n",
+        encoding="utf-8",
+    )
+    subtitle_before = subtitle_file.read_bytes()
+
+    session = workfolder / "local" / f"clip__{task_id}"
+    media = session / "media"
+    metadata = session / "metadata"
+    media.mkdir(parents=True)
+    metadata.mkdir(parents=True)
+    (media / "video_source.mp4").write_bytes(b"video")
+    (media / "audio_vocals.wav").write_bytes(b"vocals")
+    (media / "audio_bgm.wav").write_bytes(b"bgm")
+    (metadata / "local_info.json").write_text(
+        json.dumps({"subtitle_path": str(subtitle_file)}),
+        encoding="utf-8",
+    )
+    (metadata / "asr.json").write_bytes(b'{"upstream":"asr"}')
+    (metadata / "asr_fixed.json").write_bytes(b'{"upstream":"asr_fixed"}')
+    (metadata / "translation.zh.json").write_bytes(b'{"downstream":"translation"}')
+    upstream_file = metadata / upstream_name
+    upstream_before = upstream_file.read_bytes()
+
+    database.create_task(task_url, task_id=task_id, execution_mode="manual")
+    database.update_task(task_id, status="paused", session_path=str(session))
+    for completed_stage in ("download", "separate", "asr", "asr_fix", "translate"):
+        database.update_stage(
+            task_id,
+            completed_stage,
+            status="succeeded",
+            completed_at=database.now_iso(),
+        )
+    enqueued: list[str] = []
+    monkeypatch.setattr(main.worker, "enqueue", lambda tid: enqueued.append(tid))
+
+    response = authenticated_client().post(
+        f"/api/tasks/{task_id}/stages/{stage_name}/redo"
+    )
+
+    assert response.status_code == 200
+    assert enqueued == [task_id]
+    assert not (metadata / generated_name).exists()
+
+    pipeline.PipelineRunner(task_id).run()
+
+    task = database.get_task(task_id)
+    stages = {stage["name"]: stage for stage in task["stages"]}
+    assert task["status"] == "paused"
+    assert stages[stage_name]["status"] == "succeeded"
+    stage_order = [stage["name"] for stage in task["stages"]]
+    assert all(
+        stages[name]["status"] == "pending"
+        for name in stage_order[stage_order.index(stage_name) + 1 :]
+    )
+    assert upstream_file.read_bytes() == upstream_before
+    assert subtitle_file.read_bytes() == subtitle_before
+    generated = json.loads((metadata / generated_name).read_text(encoding="utf-8"))
+    if stage_name == "asr_fix":
+        assert [item["text"] for item in generated["result"]["utterances"]] == [
+            "你好",
+            "世界",
+        ]
+    else:
+        assert [item["dst"] for item in generated["translation"]] == [
+            "你好",
+            "世界",
+        ]
 
 
 def test_redo_stage_runtime_failure_preserves_artifacts_and_state(monkeypatch, tmp_path):


### PR DESCRIPTION
## 问题

本地视频上传 SRT 后，手动任务重做 `asr_fix` 或 `translate` 会必然失败。redo 正确删除当前阶段及下游产物，但 pipeline 只尝试复用已被删除的 `asr_fixed.json` 或 `translation.*.json`。

## 根因

上传 SRT 的 `asr` 阶段提前一次性生成了 asr、asr_fix、translate 三个阶段的文件，而后两个阶段没有自己的生成逻辑。产物所有权与 stage reset 语义不一致。

## 修复

- 共享原始 SRT 的解析与 payload 构建逻辑
- `asr`、`asr_fix`、`translate` 分别只原子写入自己的阶段产物
- redo 后从持久化的原始上传 SRT 重建当前阶段文件
- `asr` 不再提前创建后两阶段文件，恢复严格阶段所有权
- 解析与 JSON 序列化在替换前完成；写入使用私有临时文件和原子替换
- 普通 Whisper、句子修复和 OpenAI 翻译路径保持不变

## 验证

- `asr_fix` redo 端到端：通过，任务在该阶段成功后按手动模式暂停
- `translate` redo 端到端：通过，任务在该阶段成功后按手动模式暂停
- 两条路径均确认下游保持 pending、原始 SRT 与有效上游文件字节不变
- 注入 `fsync`/原子替换失败：旧目标、其他阶段文件和原始 SRT 均不变，临时文件清理完成
- 相关测试：110 项通过
- 后端全量：307 项通过，1 个既有 `pydub/audioop` 弃用警告
- `git diff --check`：通过
- 独立复核：无阻断，可合并
