### PR TITLE
修复上传失败后的孤儿文件

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import uuid
@@ -34,6 +35,8 @@ ALLOWED_SUBTITLE_SUFFIXES = {".srt"}
 LOCAL_UPLOAD_CHUNK_SIZE = 1024 * 1024
 MAX_LOCAL_UPLOAD_BYTES = int(os.getenv("LOCAL_UPLOAD_MAX_BYTES", str(4 * 1024 * 1024 * 1024)))
 MAX_LOCAL_SUBTITLE_BYTES = int(os.getenv("LOCAL_SUBTITLE_MAX_BYTES", str(20 * 1024 * 1024)))
+
+logger = logging.getLogger(__name__)
 
 TaskListStatus = Literal["all", "queued", "running", "paused", "succeeded", "failed"]
 TaskListExecutionMode = Literal["all", "auto", "manual"]
@@ -394,6 +397,17 @@ def _validate_uploaded_srt(path: Path) -> None:
         raise HTTPException(status_code=400, detail=f"Invalid SRT subtitle file: {exc}") from exc
 
 
+def _rollback_local_upload(task_id: str) -> None:
+    try:
+        remove_upload(WORKFOLDER, task_id)
+    except Exception:
+        logger.exception("Failed to remove local upload files for task %s", task_id)
+    try:
+        database.delete_task(task_id)
+    except Exception:
+        logger.exception("Failed to remove local upload database record for task %s", task_id)
+
+
 @app.post("/api/tasks/upload", status_code=201)
 def upload_local_video(
     direction: str = Form("en-zh"),
@@ -404,9 +418,14 @@ def upload_local_video(
     if direction not in LOCAL_UPLOAD_DIRECTIONS:
         raise HTTPException(status_code=422, detail="Unsupported local video direction.")
 
-    _ensure_runtime_ready()
     original_name = Path(file.filename or "").name.strip()
     stored_name = _clean_upload_filename(original_name)
+    stored_subtitle_name = None
+    if subtitle_file is not None:
+        stored_subtitle_name = _clean_subtitle_filename(subtitle_file.filename)
+    normalized_execution_mode = normalize_execution_mode(execution_mode)
+    _ensure_runtime_ready()
+
     task_id = str(uuid.uuid4())
     try:
         _save_uploaded_file(
@@ -415,9 +434,8 @@ def upload_local_video(
             max_bytes=MAX_LOCAL_UPLOAD_BYTES,
             too_large_detail="Uploaded video is too large.",
         )
-        if subtitle_file is not None and subtitle_file.filename:
-            subtitle_name = _clean_subtitle_filename(subtitle_file.filename)
-            subtitle_path = uploaded_subtitle_dir(WORKFOLDER, task_id) / subtitle_name
+        if subtitle_file is not None and stored_subtitle_name is not None:
+            subtitle_path = uploaded_subtitle_dir(WORKFOLDER, task_id) / stored_subtitle_name
             _save_uploaded_file(
                 subtitle_file,
                 subtitle_path,
@@ -425,19 +443,22 @@ def upload_local_video(
                 too_large_detail="Uploaded subtitle is too large.",
             )
             _validate_uploaded_srt(subtitle_path)
-    except HTTPException:
-        remove_upload(WORKFOLDER, task_id)
-        raise
 
-    url = f"local://upload/{task_id}?direction={direction}&filename={quote(original_name)}"
-    database.create_task(
-        url,
-        task_id=task_id,
-        execution_mode=normalize_execution_mode(execution_mode),
-    )
-    database.update_task(task_id, title=Path(original_name).stem)
-    worker.enqueue(task_id)
-    return database.get_task(task_id)
+        url = f"local://upload/{task_id}?direction={direction}&filename={quote(original_name)}"
+        database.create_task(
+            url,
+            task_id=task_id,
+            execution_mode=normalized_execution_mode,
+        )
+        database.update_task(task_id, title=Path(original_name).stem)
+        task = database.get_task(task_id)
+        if task is None:
+            raise RuntimeError(f"Local upload task {task_id} was not persisted.")
+        worker.enqueue(task_id)
+        return task
+    except Exception:
+        _rollback_local_upload(task_id)
+        raise
 
 
 @app.get("/api/tasks/current")

--- a/backend/tests/test_settings_and_api.py
+++ b/backend/tests/test_settings_and_api.py
@@ -4,6 +4,7 @@ import json
 import re
 import sqlite3
 import threading
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
@@ -1287,6 +1288,73 @@ def test_upload_local_video_can_save_translated_srt(monkeypatch, tmp_path):
     assert subtitle_files[0].read_bytes().startswith(b"1\n00:00:00,000")
 
 
+@pytest.mark.parametrize(
+    ("data", "files", "expected_detail"),
+    [
+        (
+            {"direction": "fr-zh", "execution_mode": "auto"},
+            {"file": ("clip.mp4", b"mp4data", "video/mp4")},
+            "Unsupported local video direction.",
+        ),
+        (
+            {"direction": "en-zh", "execution_mode": "batch"},
+            {"file": ("clip.mp4", b"mp4data", "video/mp4")},
+            "execution_mode must be one of: auto, manual",
+        ),
+        (
+            {"direction": "en-zh", "execution_mode": "auto"},
+            {"file": (".", b"mp4data", "video/mp4")},
+            "Video filename is required.",
+        ),
+        (
+            {"direction": "en-zh", "execution_mode": "auto"},
+            {"file": ("clip.txt", b"mp4data", "text/plain")},
+            "Unsupported video file type.",
+        ),
+        (
+            {"direction": "en-zh", "execution_mode": "auto"},
+            {
+                "file": ("clip.mp4", b"mp4data", "video/mp4"),
+                "subtitle_file": (".", b"subtitle", "application/x-subrip"),
+            },
+            "Subtitle filename is required.",
+        ),
+        (
+            {"direction": "en-zh", "execution_mode": "auto"},
+            {
+                "file": ("clip.mp4", b"mp4data", "video/mp4"),
+                "subtitle_file": ("clip.vtt", b"WEBVTT", "text/vtt"),
+            },
+            "Only .srt subtitle files are supported.",
+        ),
+    ],
+)
+def test_upload_local_video_validates_parameters_before_writing(
+    monkeypatch,
+    tmp_path,
+    data,
+    files,
+    expected_detail,
+):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    write_attempts: list[Path] = []
+
+    def record_write(_file, destination, **_kwargs):
+        write_attempts.append(destination)
+        raise AssertionError("invalid upload parameters must be rejected before writing")
+
+    monkeypatch.setattr(main, "_save_uploaded_file", record_write)
+    client = authenticated_client()
+
+    response = client.post("/api/tasks/upload", data=data, files=files)
+
+    assert response.status_code == 422
+    assert response.json()["detail"] == expected_detail
+    assert write_attempts == []
+    assert database.list_tasks() == []
+    assert not any((config.WORKFOLDER / "_uploads").glob("*"))
+
+
 def test_upload_local_video_rejects_non_srt_subtitle(monkeypatch, tmp_path):
     configure_tmp_runtime(monkeypatch, tmp_path)
     client = authenticated_client()
@@ -1322,6 +1390,71 @@ def test_upload_local_video_rejects_malformed_srt_and_cleans_upload(monkeypatch,
     assert response.status_code == 400
     assert "Invalid SRT subtitle file" in response.json()["detail"]
     assert enqueued == []
+    assert database.list_tasks() == []
+    assert not any((config.WORKFOLDER / "_uploads").glob("*"))
+
+
+def test_upload_local_video_database_failure_rolls_back_task_and_files(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    enqueued: list[str] = []
+    monkeypatch.setattr(main.worker, "enqueue", lambda task_id: enqueued.append(task_id))
+    client = authenticated_client()
+
+    def fail_title_update(_task_id, **_fields):
+        raise sqlite3.OperationalError("injected title update failure")
+
+    monkeypatch.setattr(database, "update_task", fail_title_update)
+
+    with pytest.raises(sqlite3.OperationalError, match="injected title update failure"):
+        client.post(
+            "/api/tasks/upload",
+            data={"direction": "en-zh", "execution_mode": "auto"},
+            files={"file": ("clip.mp4", b"mp4data", "video/mp4")},
+        )
+
+    assert enqueued == []
+    assert database.list_tasks() == []
+    assert not any((config.WORKFOLDER / "_uploads").glob("*"))
+
+
+def test_upload_local_video_unexpected_write_failure_removes_partial_upload(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    client = authenticated_client()
+
+    def fail_after_partial_write(_file, destination, **_kwargs):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"partial")
+        raise OSError("injected upload write failure")
+
+    monkeypatch.setattr(main, "_save_uploaded_file", fail_after_partial_write)
+
+    with pytest.raises(OSError, match="injected upload write failure"):
+        client.post(
+            "/api/tasks/upload",
+            data={"direction": "en-zh", "execution_mode": "auto"},
+            files={"file": ("clip.mp4", b"mp4data", "video/mp4")},
+        )
+
+    assert database.list_tasks() == []
+    assert not any((config.WORKFOLDER / "_uploads").glob("*"))
+
+
+def test_upload_local_video_enqueue_failure_rolls_back_task_and_files(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    client = authenticated_client()
+
+    def fail_enqueue(_task_id):
+        raise RuntimeError("injected enqueue failure")
+
+    monkeypatch.setattr(main.worker, "enqueue", fail_enqueue)
+
+    with pytest.raises(RuntimeError, match="injected enqueue failure"):
+        client.post(
+            "/api/tasks/upload",
+            data={"direction": "en-zh", "execution_mode": "auto"},
+            files={"file": ("clip.mp4", b"mp4data", "video/mp4")},
+        )
+
     assert database.list_tasks() == []
     assert not any((config.WORKFOLDER / "_uploads").glob("*"))
 


### PR DESCRIPTION
## 问题

本地上传接口会在校验 `execution_mode` 和字幕后缀之前写入文件；数据库更新、任务查询或入队出现异常时也不在原清理范围内，可能留下上传目录或无效任务记录。

## 根因

上传参数校验、文件持久化、数据库写入和任务入队被拆在不同异常边界中，且原逻辑只捕获文件阶段的 `HTTPException`。

## 修复

- 在写盘和生成任务 ID 前完成方向、执行模式、视频文件名/后缀、字幕文件名/后缀校验。
- 将视频写入、字幕写入与解析、数据库创建/更新/查询和任务入队纳入同一异常边界。
- 任一常规异常发生后，分别补偿删除整个上传目录和数据库任务；清理异常只记录安全日志，不覆盖原始根因。
- 增加非法参数零写盘、部分写入异常、数据库更新异常和入队异常的回归测试。

## 验证

- 上传专项：13 passed。
- 全量后端：316 passed，1 个与本分支无关的 pydub/audioop 弃用预警。
- `git diff --check`：通过。
- 独立复核：无阻断项。
