### PR TITLE
隔离 worker 单任务异常

### DIFF
--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -2,27 +2,93 @@
 
 from __future__ import annotations
 
+import logging
 import queue
 import threading
+import traceback
 from typing import Callable
 
-from . import database
+from . import database, runtime_security
 
 
 _queue: "queue.Queue[str]" = queue.Queue()
 _thread: threading.Thread | None = None
 _lock = threading.Lock()
+logger = logging.getLogger(__name__)
 
 
 def enqueue(task_id: str) -> None:
     _queue.put(task_id)
 
 
+def _append_failure_log(task_id: str, traceback_text: str) -> None:
+    path = database.log_path(task_id)
+    timestamp = database.now_iso()
+    with runtime_security.open_private_append_text(path) as handle:
+        handle.write(f"[{timestamp}] Worker caught an unhandled runner exception\n")
+        for line in traceback_text.rstrip().splitlines():
+            handle.write(f"[{timestamp}] {line}\n")
+
+
+def _record_runner_failure(task_id: str, exc: Exception) -> None:
+    error_message = str(exc).strip() or type(exc).__name__
+    traceback_text = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
+
+    task = None
+    try:
+        task = database.get_task(task_id)
+    except Exception:
+        logger.exception("Failed to load task %s after runner exception", task_id)
+
+    if task is not None:
+        completed_at = database.now_iso()
+        try:
+            database.update_task(
+                task_id,
+                status="failed",
+                error_message=error_message,
+                completed_at=completed_at,
+            )
+        except Exception:
+            logger.exception("Failed to mark task %s as failed", task_id)
+
+        failed_stage = task.get("current_stage")
+        if failed_stage and failed_stage != "done":
+            try:
+                database.update_stage(
+                    task_id,
+                    failed_stage,
+                    status="failed",
+                    completed_at=completed_at,
+                    error_message=error_message,
+                    last_message="Failed",
+                )
+            except Exception:
+                logger.exception("Failed to mark task %s stage %s as failed", task_id, failed_stage)
+
+    try:
+        _append_failure_log(task_id, traceback_text)
+    except Exception:
+        logger.exception("Failed to write runner exception log for task %s", task_id)
+
+
 def _loop(runner: Callable[[str], None]) -> None:
     while True:
         task_id = _queue.get()
-        runner(task_id)
-        _queue.task_done()
+        try:
+            runner(task_id)
+        except Exception as exc:
+            logger.error(
+                "Unhandled worker runner exception for task %s",
+                task_id,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+            try:
+                _record_runner_failure(task_id, exc)
+            except Exception:
+                logger.exception("Failed to record runner exception for task %s", task_id)
+        finally:
+            _queue.task_done()
 
 
 def start(runner: Callable[[str], None]) -> None:

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import queue
 import threading
 
 from backend.app import database, worker
@@ -28,3 +29,100 @@ def test_worker_picks_up_pending_and_new_tasks(monkeypatch, tmp_path):
     assert done.wait(timeout=2.0)
     assert executed[:2] == pre_queued
     assert executed[-1] == "late-task"
+
+
+def test_worker_isolates_runner_exception_and_processes_next_task(monkeypatch, tmp_path):
+    monkeypatch.setattr(database, "DB_PATH", tmp_path / "worker-isolation.sqlite")
+    database.init_db()
+    failed_task = database.create_task(
+        "https://www.youtube.com/watch?v=failedtask1",
+        task_id="failedtask1",
+    )
+    successful_task = database.create_task(
+        "https://www.youtube.com/watch?v=successtask",
+        task_id="successtask",
+    )
+    work_queue: queue.Queue[str] = queue.Queue()
+    monkeypatch.setattr(worker, "_queue", work_queue)
+
+    executed: list[str] = []
+    second_finished = threading.Event()
+
+    def runner(task_id: str) -> None:
+        executed.append(task_id)
+        if task_id == failed_task:
+            raise RuntimeError("first runner exploded")
+        database.update_task(
+            task_id,
+            status="succeeded",
+            current_stage="done",
+            completed_at=database.now_iso(),
+        )
+        second_finished.set()
+
+    thread = threading.Thread(target=worker._loop, args=(runner,), daemon=True)
+    thread.start()
+    work_queue.put(failed_task)
+    work_queue.put(successful_task)
+
+    assert second_finished.wait(timeout=2.0)
+    queue_joined = threading.Event()
+
+    def join_queue() -> None:
+        work_queue.join()
+        queue_joined.set()
+
+    threading.Thread(target=join_queue, daemon=True).start()
+    assert queue_joined.wait(timeout=2.0)
+
+    failed = database.get_task(failed_task)
+    failed_stages = {stage["name"]: stage for stage in failed["stages"]}
+    succeeded = database.get_task(successful_task)
+    log_content = database.log_path(failed_task).read_text(encoding="utf-8")
+
+    assert executed == [failed_task, successful_task]
+    assert thread.is_alive()
+    assert failed["status"] == "failed"
+    assert failed["error_message"] == "first runner exploded"
+    assert failed_stages["download"]["status"] == "failed"
+    assert "Worker caught an unhandled runner exception" in log_content
+    assert "RuntimeError: first runner exploded" in log_content
+    assert succeeded["status"] == "succeeded"
+
+
+def test_worker_continues_when_failure_reporter_also_raises(monkeypatch, caplog):
+    work_queue: queue.Queue[str] = queue.Queue()
+    monkeypatch.setattr(worker, "_queue", work_queue)
+
+    def fail_reporter(_task_id: str, _exc: Exception) -> None:
+        raise RuntimeError("reporter exploded")
+
+    monkeypatch.setattr(worker, "_record_runner_failure", fail_reporter)
+    processed: list[str] = []
+    second_finished = threading.Event()
+
+    def runner(task_id: str) -> None:
+        processed.append(task_id)
+        if task_id == "first":
+            raise RuntimeError("runner exploded")
+        second_finished.set()
+
+    thread = threading.Thread(target=worker._loop, args=(runner,), daemon=True)
+    thread.start()
+    work_queue.put("first")
+    work_queue.put("second")
+
+    assert second_finished.wait(timeout=2.0)
+    queue_joined = threading.Event()
+
+    def join_queue() -> None:
+        work_queue.join()
+        queue_joined.set()
+
+    threading.Thread(target=join_queue, daemon=True).start()
+    assert queue_joined.wait(timeout=2.0)
+
+    assert thread.is_alive()
+    assert processed == ["first", "second"]
+    assert "Unhandled worker runner exception for task first" in caplog.text
+    assert "Failed to record runner exception for task first" in caplog.text


### PR DESCRIPTION
## 问题

唯一 worker 线程在执行某个任务时若遇到未被 runner 自身捕获的异常，会跳过 `queue.task_done()` 并永久退出，队列中的后续任务不再执行。

## 根因

worker 循环直接调用 runner，没有单任务级 `try/except/finally`；pipeline 启动阶段和失败处理自身仍存在异常逃逸可能，因此不能只依赖 runner 内部捕获。

## 修复

- 为每个任务建立独立的异常边界，并在 `finally` 中始终调用 `task_done()`。
- runner 异常时先写服务 traceback，再以降级方式将任务及当前阶段标记为失败。
- 将完整 traceback 追加到受私有权限保护的任务日志，供现有日志接口诊断。
- 数据库、阶段更新或任务日志记录再次失败时只记录服务日志，不让失败记录器终止 worker。
- 增加“首任务异常、第二任务继续成功”和“失败记录器也异常”的回归测试。

## 验证

- Worker 专项：3 passed；独立连续运行 10 次稳定通过。
- 全量后端：318 passed，1 个与本分支无关的 pydub/audioop 弃用预警。
- `git diff --check`：通过。
- 独立复核：无阻断项。
