### PR TITLE
修复手动任务最终阶段完成状态

### DIFF
--- a/backend/app/pipeline.py
+++ b/backend/app/pipeline.py
@@ -100,7 +100,7 @@ class PipelineRunner:
                     self.log(f"[{stage.name}] Reused cached output")
                     continue
                 self._run_stage(stage.name)
-                if execution_mode == "manual":
+                if execution_mode == "manual" and stage != STAGES[-1]:
                     database.update_task(self.task_id, status="paused")
                     self.log(f"Paused after [{stage.name}], waiting for manual continue")
                     return

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from backend.app import database
 from backend.app import pipeline
 from backend.app.pipeline import PipelineRunner
+from backend.app.stages import STAGES
 
 
 def configure_db(monkeypatch, tmp_path):
@@ -243,6 +244,76 @@ def test_pipeline_manual_pauses_after_each_stage(monkeypatch, tmp_path):
     assert task["stages"][2]["status"] == "pending"
 
 
+def test_pipeline_manual_completes_immediately_after_final_stage(monkeypatch, tmp_path):
+    configure_db(monkeypatch, tmp_path)
+    task_id = database.create_task(
+        "https://www.youtube.com/watch?v=manualfinal",
+        task_id="manualfinal",
+        execution_mode="manual",
+    )
+    session = _cached_session(tmp_path)
+    final_path = session / "media" / "video_final.mp4"
+    visited: list[str] = []
+
+    def make_stage_handler(stage_name: str):
+        def handler(self, _task):
+            visited.append(stage_name)
+            if stage_name == "download":
+                self.artifacts.session = session
+                self.artifacts.video_file = session / "media" / "video_source.mp4"
+                database.update_task(self.task_id, session_path=str(session), title="manual-final")
+            elif stage_name == "separate":
+                self.artifacts.vocals_file = session / "media" / "audio_vocals.wav"
+                self.artifacts.bgm_file = session / "media" / "audio_bgm.wav"
+            elif stage_name == "asr":
+                self.artifacts.asr_file = session / "metadata" / "asr.json"
+            elif stage_name == "asr_fix":
+                self.artifacts.asr_fixed_file = session / "metadata" / "asr_fixed.json"
+            elif stage_name == "translate":
+                self.artifacts.translation_file = session / "metadata" / "translation.zh.json"
+            elif stage_name == "split_audio":
+                self.artifacts.vocals_dir = session / "segments" / "vocals"
+            elif stage_name == "tts":
+                self.artifacts.tts_dir = session / "segments" / "tts"
+            elif stage_name == "merge_audio":
+                self.artifacts.dubbing_file = session / "tmp" / "audio_dubbing.wav"
+                self.artifacts.timings_file = session / "metadata" / "timings.json"
+            elif stage_name == "merge_video":
+                self.artifacts.final_video = final_path
+
+        return handler
+
+    for stage in STAGES:
+        monkeypatch.setattr(PipelineRunner, f"_{stage.name}", make_stage_handler(stage.name))
+
+    for index, stage in enumerate(STAGES):
+        if index > 0:
+            database.queue_task_for_continue(task_id)
+
+        PipelineRunner(task_id).run()
+        task = database.get_task(task_id)
+        stage_statuses = [entry["status"] for entry in task["stages"]]
+
+        assert stage_statuses[: index + 1] == ["succeeded"] * (index + 1)
+        assert stage_statuses[index + 1 :] == ["pending"] * (len(STAGES) - index - 1)
+        if index < len(STAGES) - 1:
+            assert task["status"] == "paused"
+            assert task["current_stage"] == stage.name
+            assert task["final_video_path"] is None
+            assert task["completed_at"] is None
+        else:
+            assert task["status"] == "succeeded"
+            assert task["current_stage"] == "done"
+            assert task["final_video_path"] == str(final_path)
+            assert task["completed_at"] is not None
+
+    assert visited == [stage.name for stage in STAGES]
+    assert [stage["progress"] for stage in task["stages"]] == [100] * len(STAGES)
+    log_content = database.log_path(task_id).read_text(encoding="utf-8")
+    assert "Task succeeded" in log_content
+    assert "Paused after [merge_video]" not in log_content
+
+
 def test_pipeline_manual_switch_to_auto_runs_remaining_stages(monkeypatch, tmp_path):
     configure_db(monkeypatch, tmp_path)
     task_id = database.create_task(
@@ -369,4 +440,3 @@ def test_pipeline_uses_uploaded_srt_and_skips_model_stages(monkeypatch, tmp_path
     assert "skipped Whisper" in log_content
     assert "skipped sentence splitting" in log_content
     assert "skipped OpenAI translation" in log_content
-


### PR DESCRIPTION
## 问题

手动任务完成第 9 个 `merge_video` 阶段后仍会进入暂停状态，必须再点击一次继续，才能恢复九个缓存阶段并写入最终成功状态。

## 根因

pipeline 在任何手动阶段成功后都无条件写入 `paused` 并返回，导致循环后的最终成功落库逻辑在 `merge_video` 后不可达。

## 修复

- 仅在手动模式的非最终阶段完成后暂停。
- 最终阶段成功后继续执行既有收尾逻辑，同轮写入 `succeeded`、`done`、最终视频路径和完成时间。
- 新增完整手动九阶段回归：九次独立 Runner 调用、前八次逐阶段暂停、最后一次直接成功，并验证缓存恢复、阶段进度和成功日志。

## 验证

- 手动模式专项：3 passed。
- 相关 pipeline 专项：10 passed。
- 全量后端：319 passed，1 个与本分支无关的 pydub/audioop 弃用预警。
- `git diff --check`：通过。
- 独立复核：无阻断项。
