### PR TITLE
修复前端轮询竞态与迟到响应覆盖

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
@@ -87,5 +87,87 @@ describe("本地视频字幕选择", () => {
     expect((form.get("file") as File).name).toBe("video-b.mp4")
     expect(form.has("subtitle_file")).toBe(false)
     expect(mocks.push).toHaveBeenCalledWith("/tasks/task-b")
+  })
+})
+
+describe("任务列表轮询", () => {
+  it("筛选变化后丢弃已取消请求的迟到响应", async () => {
+    let resolveOldRequest!: (response: Response) => void
+    const oldRequest = new Promise<Response>((resolve) => {
+      resolveOldRequest = resolve
+    })
+    let listRequestCount = 0
+
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const path = String(input)
+      if (!path.startsWith("/api/tasks")) throw new Error(`未预期的请求: ${path}`)
+      listRequestCount += 1
+      if (listRequestCount === 1) return oldRequest
+      return new Response(JSON.stringify({
+        tasks: [{
+          id: "new-task",
+          url: "https://example.com/new",
+          title: "新列表任务",
+          status: "succeeded",
+          current_stage: "done",
+          final_video_path: null,
+          error_message: null,
+          created_at: "2026-07-14T00:00:00Z",
+          started_at: null,
+          completed_at: null,
+          execution_mode: "auto",
+        }],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    vi.stubGlobal("fetch", mocks.fetch)
+
+    render(
+      <LanguageProvider>
+        <Home />
+      </LanguageProvider>,
+    )
+
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByPlaceholderText("搜索标题、链接或任务 ID"), {
+      target: { value: "new" },
+    })
+
+    expect(await screen.findByText("新列表任务")).toBeInTheDocument()
+    const oldSignal = mocks.fetch.mock.calls[0][1]?.signal
+    expect(oldSignal?.aborted).toBe(true)
+
+    await act(async () => {
+      resolveOldRequest(new Response(JSON.stringify({
+        tasks: [{
+          id: "old-task",
+          url: "https://example.com/old",
+          title: "迟到的旧任务",
+          status: "running",
+          current_stage: "download",
+          final_video_path: null,
+          error_message: null,
+          created_at: "2026-07-13T00:00:00Z",
+          started_at: null,
+          completed_at: null,
+          execution_mode: "auto",
+        }],
+        total: 1,
+        page: 1,
+        page_size: 20,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }))
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText("新列表任务")).toBeInTheDocument()
+    expect(screen.queryByText("迟到的旧任务")).not.toBeInTheDocument()
   })
 })

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react"
+import { ChangeEvent, FormEvent, useCallback, useRef, useState } from "react"
 import { ChevronLeft, ChevronRight, Play, Search, Upload } from "lucide-react"
 
 import {
@@ -14,11 +14,13 @@ import {
   TaskListStatus,
   TaskSummary,
   createTask,
+  isAbortError,
   listTasks,
   uploadLocalTask,
 } from "@/lib/api"
 import { useI18n } from "@/lib/i18n"
 import { statusBadgeClass } from "@/lib/status"
+import { SerialPollingContext, useSerialPolling } from "@/lib/use-serial-polling"
 import { AppHeader } from "@/components/app-header"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -137,7 +139,7 @@ export default function Home() {
     { value: "title_desc", label: t.home.sortTitleDesc },
   ]
 
-  function applyTaskList(result: TaskListResponse) {
+  const applyTaskList = useCallback((result: TaskListResponse) => {
     const lastPage = Math.max(1, Math.ceil(result.total / result.page_size))
     setTaskTotal(result.total)
     if (result.total > 0 && result.tasks.length === 0 && result.page > lastPage) {
@@ -146,46 +148,36 @@ export default function Home() {
       return
     }
     setTasks(result.tasks)
-  }
+  }, [])
 
-  async function refreshTasks() {
-    const result = await listTasks({
-      page: taskPage,
-      page_size: taskPageSize,
-      q: taskQuery,
-      status: taskStatus,
-      execution_mode: taskExecutionMode,
-      sort: taskSort,
-    })
-    applyTaskList(result)
-  }
-
-  useEffect(() => {
-    let cancelled = false
-
-    const loadTasks = async () => {
-      try {
-        const result = await listTasks({
-          page: taskPage,
-          page_size: taskPageSize,
-          q: taskQuery,
-          status: taskStatus,
-          execution_mode: taskExecutionMode,
-          sort: taskSort,
-        })
-        if (!cancelled) applyTaskList(result)
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : t.home.loadError)
+  const pollTasks = useCallback(async ({ signal, isCurrent }: SerialPollingContext) => {
+    try {
+      const result = await listTasks({
+        page: taskPage,
+        page_size: taskPageSize,
+        q: taskQuery,
+        status: taskStatus,
+        execution_mode: taskExecutionMode,
+        sort: taskSort,
+      }, signal)
+      if (isCurrent()) applyTaskList(result)
+    } catch (err) {
+      if (isCurrent() && !isAbortError(err)) {
+        setError(err instanceof Error ? err.message : t.home.loadError)
       }
     }
+  }, [
+    applyTaskList,
+    taskExecutionMode,
+    taskPage,
+    taskPageSize,
+    taskQuery,
+    taskSort,
+    taskStatus,
+    t.home.loadError,
+  ])
 
-    loadTasks()
-    const interval = window.setInterval(loadTasks, 2000)
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [taskExecutionMode, taskPage, taskPageSize, taskQuery, taskSort, taskStatus, t.home.loadError])
+  useSerialPolling(pollTasks)
 
   function resetTaskPage() {
     setTaskPage(1)
@@ -225,7 +217,6 @@ export default function Home() {
       if (subtitleInputRef.current) {
         subtitleInputRef.current.value = ""
       }
-      refreshTasks().catch(() => undefined)
       router.push(`/tasks/${created.id}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : t.home.createError)

--- a/apps/web/src/app/tasks/[id]/page.test.tsx
+++ b/apps/web/src/app/tasks/[id]/page.test.tsx
@@ -1,0 +1,124 @@
+import { Suspense } from "react"
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import TaskDetailPage from "@/app/tasks/[id]/page"
+import { Task, TaskStatus } from "@/lib/api"
+import { LanguageProvider } from "@/lib/i18n"
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(),
+  replace: vi.fn(),
+}))
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}))
+
+vi.mock("@/components/app-header", () => ({
+  AppHeader: () => null,
+}))
+
+function taskWithStatus(status: TaskStatus): Task {
+  return {
+    id: "task-race",
+    url: "https://example.com/task-race",
+    title: "轮询竞态任务",
+    status,
+    current_stage: status === "queued" ? "separate" : "download",
+    session_path: null,
+    final_video_path: null,
+    error_message: null,
+    created_at: "2026-07-14T00:00:00Z",
+    started_at: null,
+    completed_at: null,
+    execution_mode: "manual",
+    stages: [{
+      task_id: "task-race",
+      name: "download",
+      label: "Download",
+      status: status === "paused" ? "succeeded" : "pending",
+      progress: status === "paused" ? 100 : null,
+      started_at: null,
+      completed_at: null,
+      last_message: null,
+      error_message: null,
+    }],
+  }
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  window.localStorage.clear()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+describe("任务详情轮询", () => {
+  it("continue 返回新状态后不会被动作前的迟到轮询覆盖", async () => {
+    let resolveOldPoll!: (response: Response) => void
+    const oldPoll = new Promise<Response>((resolve) => {
+      resolveOldPoll = resolve
+    })
+    let taskGetCount = 0
+
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input)
+      const method = init?.method || "GET"
+      if (method === "GET" && path === "/api/tasks/task-race") {
+        taskGetCount += 1
+        return taskGetCount === 1 ? jsonResponse(taskWithStatus("paused")) : oldPoll
+      }
+      if (method === "GET" && path === "/api/tasks/task-race/log") {
+        return new Response("initial log", { status: 200 })
+      }
+      if (method === "POST" && path === "/api/tasks/task-race/continue") {
+        return jsonResponse(taskWithStatus("queued"))
+      }
+      throw new Error(`未预期的请求: ${method} ${path}`)
+    })
+    vi.stubGlobal("fetch", mocks.fetch)
+
+    const user = userEvent.setup()
+    const params = Promise.resolve({ id: "task-race" })
+    await act(async () => {
+      render(
+        <LanguageProvider>
+          <Suspense fallback={<div>loading</div>}>
+            <TaskDetailPage params={params} />
+          </Suspense>
+        </LanguageProvider>,
+      )
+      await params
+    })
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "执行下一阶段" })).toBeInTheDocument()
+    })
+
+    await waitFor(() => expect(taskGetCount).toBe(2), { timeout: 3500 })
+
+    const oldPollCall = mocks.fetch.mock.calls.findLast(
+      ([input, init]) => String(input) === "/api/tasks/task-race" && (init?.method || "GET") === "GET",
+    )
+    await user.click(screen.getByRole("button", { name: "执行下一阶段" }))
+    await waitFor(() => expect(screen.getByText("排队中")).toBeInTheDocument())
+    expect(oldPollCall?.[1]?.signal?.aborted).toBe(true)
+
+    await act(async () => {
+      resolveOldPoll(jsonResponse(taskWithStatus("paused")))
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText("排队中")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "执行下一阶段" })).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/tasks/[id]/page.tsx
+++ b/apps/web/src/app/tasks/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useRouter } from "next/navigation"
-import { use, useEffect, useMemo, useState } from "react"
+import { use, useCallback, useMemo, useState } from "react"
 import {
   CheckCircle2,
   Circle,
@@ -24,12 +24,14 @@ import {
   finalVideoUrl,
   getTask,
   getTaskLog,
+  isAbortError,
   redoStage,
   rerunTask,
   resumeTask,
 } from "@/lib/api"
 import { useI18n } from "@/lib/i18n"
 import { statusBadgeClass } from "@/lib/status"
+import { SerialPollingContext, useSerialPolling } from "@/lib/use-serial-polling"
 import { AppHeader } from "@/components/app-header"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -104,7 +106,24 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const [redoConfirmStage, setRedoConfirmStage] = useState<string | null>(null)
   const [redoError, setRedoError] = useState("")
 
+  const pollTask = useCallback(async ({ signal, isCurrent }: SerialPollingContext) => {
+    try {
+      const next = await getTask(id, signal)
+      if (!isCurrent()) return
+      setTask(next)
+      const logText = await getTaskLog(id, signal)
+      if (isCurrent()) setLog(logText)
+    } catch (err) {
+      if (isCurrent() && !isAbortError(err)) {
+        setError(err instanceof Error ? err.message : t.task.loadError)
+      }
+    }
+  }, [id, t.task.loadError])
+
+  const invalidatePolling = useSerialPolling(pollTask)
+
   const handleDelete = async () => {
+    invalidatePolling()
     setDeleting(true)
     setDeleteError("")
     try {
@@ -117,10 +136,12 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   }
 
   const handleRerun = async () => {
+    invalidatePolling()
     setRerunning(true)
     setRerunError("")
     try {
       const next = await rerunTask(id)
+      invalidatePolling()
       setRerunOpen(false)
       setTask(next)
       setLog("")
@@ -132,10 +153,12 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   }
 
   const handleResume = async () => {
+    invalidatePolling()
     setResuming(true)
     setResumeError("")
     try {
       const next = await resumeTask(id)
+      invalidatePolling()
       setTask(next)
     } catch (err) {
       setResumeError(err instanceof Error ? err.message : t.task.resumeError)
@@ -145,10 +168,12 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   }
 
   const handleContinue = async (executionMode?: ExecutionMode) => {
+    invalidatePolling()
     setContinuing(true)
     setContinueError("")
     try {
       const next = await continueTask(id, executionMode)
+      invalidatePolling()
       setTask(next)
     } catch (err) {
       setContinueError(err instanceof Error ? err.message : t.task.continueError)
@@ -158,10 +183,12 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   }
 
   const handleRedoStage = async (stageName: string) => {
+    invalidatePolling()
     setRedoingStage(stageName)
     setRedoError("")
     try {
       const next = await redoStage(id, stageName)
+      invalidatePolling()
       setTask(next)
       return true
     } catch (err) {
@@ -185,28 +212,6 @@ export default function TaskDetailPage({ params }: { params: Promise<{ id: strin
   const isManual = task?.execution_mode === "manual"
   const canRedoStage = isManual && !isRunning && !isQueued
   const redoConfirmStageInfo = task?.stages.find((stage) => stage.name === redoConfirmStage)
-
-  useEffect(() => {
-    let cancelled = false
-    const load = async () => {
-      try {
-        const next = await getTask(id)
-        if (cancelled) return
-        setTask(next)
-        const logText = await getTaskLog(id)
-        if (cancelled) return
-        setLog(logText)
-      } catch (err) {
-        if (!cancelled) setError(err instanceof Error ? err.message : t.task.loadError)
-      }
-    }
-    load()
-    const interval = window.setInterval(load, 2000)
-    return () => {
-      cancelled = true
-      window.clearInterval(interval)
-    }
-  }, [id, t.task.loadError])
 
   const progress = useMemo(() => {
     if (!task?.stages?.length) return 0

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -13,6 +13,10 @@ export class ApiError extends Error {
   }
 }
 
+export function isAbortError(error: unknown) {
+  return error instanceof Error && error.name === "AbortError"
+}
+
 export type AuthSession = {
   authenticated: true
   csrf_token: string
@@ -211,16 +215,17 @@ export function getCurrentTask() {
   return request<Task | null>("/api/tasks/current")
 }
 
-export async function getTaskLog(taskId: string): Promise<string> {
+export async function getTaskLog(taskId: string, signal?: AbortSignal): Promise<string> {
   const response = await fetch(`/api/tasks/${taskId}/log`, {
     cache: "no-store",
     credentials: "include",
+    signal,
   })
   if (!response.ok) return parseResponse<string>(response)
   return response.text()
 }
 
-export function listTasks(params: TaskListParams | number = {}) {
+export function listTasks(params: TaskListParams | number = {}, signal?: AbortSignal) {
   const normalized = typeof params === "number" ? { page_size: params } : params
   const search = new URLSearchParams()
 
@@ -230,11 +235,14 @@ export function listTasks(params: TaskListParams | number = {}) {
   })
 
   const query = search.toString()
-  return request<TaskListResponse>(`/api/tasks${query ? `?${query}` : ""}`)
+  return request<TaskListResponse>(
+    `/api/tasks${query ? `?${query}` : ""}`,
+    signal ? { signal } : undefined,
+  )
 }
 
-export function getTask(taskId: string) {
-  return request<Task>(`/api/tasks/${taskId}`)
+export function getTask(taskId: string, signal?: AbortSignal) {
+  return request<Task>(`/api/tasks/${taskId}`, signal ? { signal } : undefined)
 }
 
 export function deleteTask(taskId: string) {

--- a/apps/web/src/lib/use-serial-polling.test.tsx
+++ b/apps/web/src/lib/use-serial-polling.test.tsx
@@ -1,0 +1,55 @@
+import { act, cleanup, render } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { type SerialPollingContext, useSerialPolling } from "@/lib/use-serial-polling"
+
+function PollingProbe({ poll }: { poll: (context: SerialPollingContext) => Promise<void> }) {
+  useSerialPolling(poll, 100)
+  return null
+}
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("串行轮询生命周期", () => {
+  it("上一轮完成前不重叠请求，卸载后取消请求和后续定时器", async () => {
+    vi.useFakeTimers()
+
+    const resolvers: Array<() => void> = []
+    const signals: AbortSignal[] = []
+    const poll = vi.fn(({ signal }: SerialPollingContext) => {
+      signals.push(signal)
+      return new Promise<void>((resolve) => {
+        resolvers.push(resolve)
+      })
+    })
+
+    const { unmount } = render(<PollingProbe poll={poll} />)
+    await act(async () => Promise.resolve())
+    expect(poll).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(poll).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolvers[0]()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(100)
+    })
+    expect(poll).toHaveBeenCalledTimes(2)
+
+    unmount()
+    expect(signals[1].aborted).toBe(true)
+
+    await act(async () => {
+      resolvers[1]()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(poll).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/src/lib/use-serial-polling.ts
+++ b/apps/web/src/lib/use-serial-polling.ts
@@ -1,0 +1,55 @@
+"use client"
+
+import { useCallback, useEffect, useRef } from "react"
+
+export type SerialPollingContext = {
+  signal: AbortSignal
+  isCurrent: () => boolean
+}
+
+export function useSerialPolling(
+  poll: (context: SerialPollingContext) => Promise<void>,
+  delayMs = 2000,
+) {
+  const controllerRef = useRef<AbortController | null>(null)
+  const generationRef = useRef(0)
+
+  const invalidate = useCallback(() => {
+    generationRef.current += 1
+    controllerRef.current?.abort()
+    controllerRef.current = null
+  }, [])
+
+  useEffect(() => {
+    let disposed = false
+    let timer: number | null = null
+
+    const run = async () => {
+      const generation = generationRef.current + 1
+      generationRef.current = generation
+      const controller = new AbortController()
+      controllerRef.current = controller
+      const isCurrent = () => (
+        !disposed
+        && !controller.signal.aborted
+        && generation === generationRef.current
+      )
+
+      try {
+        await poll({ signal: controller.signal, isCurrent })
+      } finally {
+        if (controllerRef.current === controller) controllerRef.current = null
+        if (!disposed) timer = window.setTimeout(run, delayMs)
+      }
+    }
+
+    void run()
+    return () => {
+      disposed = true
+      invalidate()
+      if (timer !== null) window.clearTimeout(timer)
+    }
+  }, [delayMs, invalidate, poll])
+
+  return invalidate
+}


### PR DESCRIPTION
## 问题

任务列表和详情页使用固定 2 秒 `setInterval` 轮询。慢请求可能彼此重叠，筛选切换或执行继续、恢复、重做、重跑后，动作前的迟到响应还可能覆盖最新状态；组件卸载也只能阻止写状态，不能真正取消网络请求。

## 根因

- 固定间隔不会等待上一轮请求完成。
- 页面只使用局部布尔值忽略部分卸载后的响应，没有取消请求或统一的请求代次。
- 详情页用户动作与后台轮询之间缺少明确的失效边界。

## 修复方案

- 新增共享串行轮询 hook：上一轮完成后才安排下一轮，并结合 `AbortController` 与单调 generation 丢弃迟到响应。
- 列表接口和详情任务、日志接口透传 `AbortSignal`；筛选变化与卸载时取消旧请求。
- 详情页删除、继续、恢复、阶段重做和整任务重跑前使旧轮询失效；状态变更成功后、写入新状态前再次失效动作期间可能产生的轮询。
- 删除创建任务成功后的旁路列表刷新，避免与轮询并发。
- 增加列表乱序、详情动作乱序及轮询串行/卸载生命周期测试。

## 验证结果

- `npm --prefix apps/web test -- --reporter=verbose`：5 个测试通过
- `npm --prefix apps/web run lint`：通过
- `cd apps/web && ./node_modules/.bin/tsc --noEmit`：通过
- `npm --prefix apps/web run build`：通过
- `git diff --check`：通过

## 审查

已完成独立合并前复审，未发现 P0–P2 阻断项。
