### PR TITLE
修复全局活跃任务计数

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -38,6 +38,7 @@ describe("本地视频字幕选择", () => {
         return new Response(JSON.stringify({
           tasks: [],
           total: 0,
+          active_count: 0,
           page: 1,
           page_size: 20,
         }), {
@@ -118,6 +119,7 @@ describe("任务列表轮询", () => {
           execution_mode: "auto",
         }],
         total: 1,
+        active_count: 37,
         page: 1,
         page_size: 20,
       }), {
@@ -158,6 +160,7 @@ describe("任务列表轮询", () => {
           execution_mode: "auto",
         }],
         total: 1,
+        active_count: 2,
         page: 1,
         page_size: 20,
       }), {
@@ -168,6 +171,57 @@ describe("任务列表轮询", () => {
     })
 
     expect(screen.getByText("新列表任务")).toBeInTheDocument()
+    expect(screen.getByText("37 个任务正在排队或运行")).toBeInTheDocument()
     expect(screen.queryByText("迟到的旧任务")).not.toBeInTheDocument()
+  })
+})
+
+describe("全局活跃任务数", () => {
+  it("切换到已完成筛选后仍显示超过单页容量的全局活跃数", async () => {
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost")
+      if (url.pathname !== "/api/tasks") throw new Error(`未预期的请求: ${url.pathname}`)
+      const succeededOnly = url.searchParams.get("status") === "succeeded"
+      return new Response(JSON.stringify({
+        tasks: succeededOnly ? [{
+          id: "completed-task",
+          url: "https://example.com/completed",
+          title: "已完成筛选结果",
+          status: "succeeded",
+          current_stage: "done",
+          final_video_path: null,
+          error_message: null,
+          created_at: "2026-07-14T00:00:00Z",
+          started_at: null,
+          completed_at: "2026-07-14T01:00:00Z",
+          execution_mode: "auto",
+        }] : [],
+        total: succeededOnly ? 1 : 0,
+        active_count: succeededOnly ? 37 : 0,
+        page: 1,
+        page_size: 20,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    vi.stubGlobal("fetch", mocks.fetch)
+
+    const user = userEvent.setup()
+    render(
+      <LanguageProvider>
+        <Home />
+      </LanguageProvider>,
+    )
+
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledTimes(1))
+    await user.click(screen.getByLabelText("状态"))
+    await user.click(await screen.findByRole("option", { name: "已完成" }))
+
+    expect(await screen.findByText("已完成筛选结果")).toBeInTheDocument()
+    expect(screen.getByText("37 个任务正在排队或运行")).toBeInTheDocument()
+    expect(mocks.fetch.mock.calls.some(([input]) => (
+      new URL(String(input), "http://localhost").searchParams.get("status") === "succeeded"
+    ))).toBe(true)
   })
 })

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -61,10 +61,6 @@ function shortUrl(url: string) {
   return url.replace(/^https?:\/\/(www\.)?/, "")
 }
 
-function activeCount(tasks: TaskSummary[]) {
-  return tasks.filter((t) => isActive(t.status)).length
-}
-
 function selectedLabel<T extends string>(options: { value: T; label: string }[], value: T) {
   return options.find((option) => option.value === value)?.label || value
 }
@@ -92,6 +88,7 @@ export default function Home() {
   const [executionMode, setExecutionMode] = useState<ExecutionMode>("auto")
   const [tasks, setTasks] = useState<TaskSummary[]>([])
   const [taskTotal, setTaskTotal] = useState(0)
+  const [activeTaskCount, setActiveTaskCount] = useState<number | null>(null)
   const [taskPage, setTaskPage] = useState(1)
   const [taskPageSize, setTaskPageSize] = useState(20)
   const [taskQuery, setTaskQuery] = useState("")
@@ -142,6 +139,11 @@ export default function Home() {
   const applyTaskList = useCallback((result: TaskListResponse) => {
     const lastPage = Math.max(1, Math.ceil(result.total / result.page_size))
     setTaskTotal(result.total)
+    setActiveTaskCount(
+      Number.isInteger(result.active_count) && result.active_count >= 0
+        ? result.active_count
+        : null,
+    )
     if (result.total > 0 && result.tasks.length === 0 && result.page > lastPage) {
       setTasks([])
       setTaskPage(lastPage)
@@ -225,7 +227,6 @@ export default function Home() {
     }
   }
 
-  const queued = activeCount(tasks)
   const hasUrl = Boolean(youtubeUrl.trim() || bilibiliUrl.trim())
   const hasLocalFile = Boolean(localFile)
   const canSubmit = Boolean((hasUrl || hasLocalFile) && !submitting)
@@ -352,9 +353,9 @@ export default function Home() {
                 </Select>
               </div>
               <div className="flex items-center justify-between gap-3">
-                {queued > 0 ? (
+                {activeTaskCount !== null && activeTaskCount > 0 ? (
                   <p className="text-xs text-muted-foreground">
-                    {activeTasksText(queued)}
+                    {activeTasksText(activeTaskCount)}
                   </p>
                 ) : (
                   <span />

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -207,6 +207,7 @@ export type TaskListParams = {
 export type TaskListResponse = {
   tasks: TaskSummary[]
   total: number
+  active_count: number
   page: number
   page_size: number
 }

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -399,12 +399,15 @@ def list_tasks_page(
 
     where_sql = f" WHERE {' AND '.join(where_parts)}" if where_parts else ""
     order_sql = TASK_LIST_SORTS.get(sort, TASK_LIST_SORTS["created_desc"])
+    active_placeholders = ", ".join("?" for _ in ACTIVE_STATUSES)
 
     with connect() as conn:
-        total = conn.execute(
-            f"SELECT COUNT(*) FROM tasks{where_sql}",
-            params,
-        ).fetchone()[0]
+        counts = conn.execute(
+            "SELECT "
+            f"(SELECT COUNT(*) FROM tasks{where_sql}) AS filtered_total, "
+            f"(SELECT COUNT(*) FROM tasks WHERE status IN ({active_placeholders})) AS active_count",
+            [*params, *ACTIVE_STATUSES],
+        ).fetchone()
         rows = conn.execute(
             f"SELECT {TASK_SUMMARY_COLUMNS} FROM tasks{where_sql} "
             f"ORDER BY {order_sql} LIMIT ? OFFSET ?",
@@ -413,7 +416,8 @@ def list_tasks_page(
 
     return {
         "tasks": [dict(row) for row in rows],
-        "total": total,
+        "total": counts["filtered_total"],
+        "active_count": counts["active_count"],
         "page": page,
         "page_size": page_size,
     }

--- a/backend/tests/test_settings_and_api.py
+++ b/backend/tests/test_settings_and_api.py
@@ -235,6 +235,7 @@ def test_list_tasks_returns_history_newest_first(monkeypatch, tmp_path):
     ids = [task["id"] for task in body["tasks"]]
     assert ids == [newer, older]
     assert body["total"] == 2
+    assert body["active_count"] == 2
     assert body["page"] == 1
     assert body["page_size"] == 20
     assert "stages" not in body["tasks"][0]
@@ -299,6 +300,48 @@ def test_list_tasks_paginates_with_total(monkeypatch, tmp_path):
     assert body["total"] == 5
     assert body["page"] == 2
     assert body["page_size"] == 2
+
+
+def test_list_tasks_active_count_ignores_filters_search_and_pagination(monkeypatch, tmp_path):
+    configure_tmp_runtime(monkeypatch, tmp_path)
+    for index in range(3):
+        make_history_task(
+            f"queued-task-{index}",
+            status="queued",
+            execution_mode="auto",
+            created_at=f"2024-01-0{index + 1}T00:00:00+00:00",
+        )
+    for index in range(2):
+        make_history_task(
+            f"running-task-{index}",
+            status="running",
+            execution_mode="auto",
+            created_at=f"2024-01-0{index + 4}T00:00:00+00:00",
+        )
+    make_history_task("paused-task", status="paused", execution_mode="manual")
+    succeeded = make_history_task(
+        "visible-success",
+        title="Visible completed task",
+        status="succeeded",
+        execution_mode="manual",
+    )
+    client = authenticated_client()
+
+    filtered = client.get(
+        "/api/tasks?q=visible&status=succeeded&execution_mode=manual&page=1&page_size=1"
+    )
+
+    assert filtered.status_code == 200
+    assert task_ids(filtered) == [succeeded]
+    assert filtered.json()["total"] == 1
+    assert filtered.json()["active_count"] == 5
+
+    empty = client.get("/api/tasks?q=no-match&page=99&page_size=1")
+
+    assert empty.status_code == 200
+    assert empty.json()["tasks"] == []
+    assert empty.json()["total"] == 0
+    assert empty.json()["active_count"] == 5
 
 
 def test_list_tasks_sorts_by_created_status_and_title(monkeypatch, tmp_path):


### PR DESCRIPTION
## 问题

首页把当前响应页中的 queued/running 任务数量当成全局活跃任务数。切换到已完成筛选时提示会消失；活跃任务超过一页时也只会显示当前页数量。

## 根因

分页接口只返回筛选后的 `total` 和当前页 `tasks`，没有独立的全局活跃计数；前端只能从当前页数组反推，天然受到搜索、筛选和分页影响。

## 修复方案

- 列表响应新增 `active_count`，只统计全库 queued/running，完全独立于搜索、状态/模式筛选、排序和分页。
- filtered total 与 active count 使用同一条 SQLite 查询的两个参数化子查询，避免参数串用并保持计数快照一致。
- 前端新增独立的 `activeTaskCount` 状态，不再从当前页任务推导；字段缺失或非法时安全隐藏，不回退到错误的局部计数。
- 保持 `total` 继续服务筛选结果标题和分页，避免混淆两种语义。
- 扩展乱序测试，确认迟到响应不能回滚全局计数。

## 验证结果

- `.venv/bin/pytest backend/tests -q`：320 个测试通过（1 个既有弃用警告）
- `npm --prefix apps/web test -- --reporter=verbose`：6 个测试通过
- `npm --prefix apps/web run lint`：通过
- `cd apps/web && ./node_modules/.bin/tsc --noEmit`：通过
- `npm --prefix apps/web run build`：通过
- `git diff --check`：通过

回归测试覆盖：已完成筛选、搜索、模式筛选、空结果/越界页、`page_size=1` 且全局 5 个活跃任务，以及前端已完成筛选仍展示 37 个全局活跃任务。

## 审查

后端与前端已分别完成独立合并前复审，均未发现 P0–P2 阻断项。
