### PR TITLE
修复任务搜索校验与错误反馈

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -225,3 +225,186 @@ describe("全局活跃任务数", () => {
     ))).toBe(true)
   })
 })
+
+describe("任务搜索校验错误", () => {
+  it("限制搜索长度，将错误数组显示为可读文本，并在恢复成功后清除错误", async () => {
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost")
+      if (url.pathname !== "/api/tasks") throw new Error(`未预期的请求: ${url.pathname}`)
+      const query = url.searchParams.get("q") || ""
+      if (query === "broken") {
+        return new Response(JSON.stringify({
+          detail: [{
+            type: "string_too_long",
+            loc: ["query", "q"],
+            msg: "搜索条件最多 200 个字符",
+            input: "不得显示的原始输入",
+          }],
+        }), {
+          status: 422,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      if (query === "malformed") {
+        return new Response(JSON.stringify({
+          detail: ["不得显示的数组裸字符串"],
+        }), {
+          status: 422,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      return new Response(JSON.stringify({
+        tasks: query === "fixed" ? [{
+          id: "recovered-task",
+          url: "https://example.com/recovered",
+          title: "恢复后的任务",
+          status: "succeeded",
+          current_stage: "done",
+          final_video_path: null,
+          error_message: null,
+          created_at: "2026-07-14T00:00:00Z",
+          started_at: null,
+          completed_at: "2026-07-14T01:00:00Z",
+          execution_mode: "auto",
+        }] : [],
+        total: query === "fixed" ? 1 : 0,
+        active_count: 0,
+        page: 1,
+        page_size: 20,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    vi.stubGlobal("fetch", mocks.fetch)
+
+    render(
+      <LanguageProvider>
+        <Home />
+      </LanguageProvider>,
+    )
+
+    const search = screen.getByPlaceholderText("搜索标题、链接或任务 ID")
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledTimes(1))
+
+    const oversizedQuery = "😀".repeat(201)
+    fireEvent.change(search, { target: { value: oversizedQuery } })
+    expect(search).toHaveValue("😀".repeat(200))
+    await waitFor(() => {
+      expect(mocks.fetch.mock.calls.some(([input]) => (
+        Array.from(new URL(String(input), "http://localhost").searchParams.get("q") || "").length === 200
+      ))).toBe(true)
+    })
+
+    fireEvent.change(search, { target: { value: "broken" } })
+
+    expect(await screen.findByText("搜索条件最多 200 个字符")).toBeInTheDocument()
+    expect(screen.queryByText("[object Object]")).not.toBeInTheDocument()
+    expect(document.body).not.toHaveTextContent("不得显示的原始输入")
+
+    fireEvent.change(search, { target: { value: "malformed" } })
+
+    expect(await screen.findByText("Request failed: 422")).toBeInTheDocument()
+    expect(document.body).not.toHaveTextContent("不得显示的数组裸字符串")
+
+    fireEvent.change(search, { target: { value: "fixed" } })
+
+    expect(await screen.findByText("恢复后的任务")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByText("搜索条件最多 200 个字符")).not.toBeInTheDocument()
+    })
+  })
+
+  it("迟到的旧成功响应不能清除新查询错误", async () => {
+    let resolveOldRequest!: (response: Response) => void
+    const oldRequest = new Promise<Response>((resolve) => {
+      resolveOldRequest = resolve
+    })
+    let requestCount = 0
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost")
+      if (url.pathname !== "/api/tasks") throw new Error(`未预期的请求: ${url.pathname}`)
+      requestCount += 1
+      if (requestCount === 1) return oldRequest
+      return new Response(JSON.stringify({
+        detail: [{ msg: "当前查询仍然失败", input: "不得显示" }],
+      }), {
+        status: 422,
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    vi.stubGlobal("fetch", mocks.fetch)
+
+    render(
+      <LanguageProvider>
+        <Home />
+      </LanguageProvider>,
+    )
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledTimes(1))
+    fireEvent.change(screen.getByPlaceholderText("搜索标题、链接或任务 ID"), {
+      target: { value: "new-query" },
+    })
+    expect(await screen.findByText("当前查询仍然失败")).toBeInTheDocument()
+
+    await act(async () => {
+      resolveOldRequest(new Response(JSON.stringify({
+        tasks: [],
+        total: 0,
+        active_count: 0,
+        page: 1,
+        page_size: 20,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }))
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText("当前查询仍然失败")).toBeInTheDocument()
+  })
+
+  it("列表恢复成功不会清除创建任务错误", async () => {
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost")
+      const method = init?.method || "GET"
+      if (url.pathname === "/api/tasks" && method === "POST") {
+        return new Response(JSON.stringify({ detail: "创建任务失败" }), {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      if (url.pathname === "/api/tasks" && method === "GET") {
+        return new Response(JSON.stringify({
+          tasks: [],
+          total: 0,
+          active_count: 0,
+          page: 1,
+          page_size: 20,
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      throw new Error(`未预期的请求: ${method} ${url.pathname}`)
+    })
+    vi.stubGlobal("fetch", mocks.fetch)
+
+    const user = userEvent.setup()
+    render(
+      <LanguageProvider>
+        <Home />
+      </LanguageProvider>,
+    )
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledTimes(1))
+    await user.type(screen.getByLabelText(/YouTube 链接/), "https://www.youtube.com/watch?v=testvideo01")
+    await user.click(screen.getByRole("button", { name: "创建任务" }))
+    expect(await screen.findByText("创建任务失败")).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText("搜索标题、链接或任务 ID"), {
+      target: { value: "refresh" },
+    })
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledTimes(3))
+
+    expect(screen.getByText("创建任务失败")).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -41,6 +41,11 @@ import {
 } from "@/components/ui/select"
 
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100]
+const TASK_SEARCH_MAX_LENGTH = 200
+
+function truncateSearchQuery(value: string) {
+  return Array.from(value).slice(0, TASK_SEARCH_MAX_LENGTH).join("")
+}
 
 function isActive(status: string) {
   return status === "queued" || status === "running"
@@ -96,6 +101,7 @@ export default function Home() {
   const [taskExecutionMode, setTaskExecutionMode] = useState<TaskListExecutionMode>("all")
   const [taskSort, setTaskSort] = useState<TaskListSort>("created_desc")
   const [error, setError] = useState("")
+  const [taskListError, setTaskListError] = useState("")
   const [submitting, setSubmitting] = useState(false)
 
   const localDirectionOptions: { value: LocalDirection; label: string }[] = [
@@ -162,10 +168,13 @@ export default function Home() {
         execution_mode: taskExecutionMode,
         sort: taskSort,
       }, signal)
-      if (isCurrent()) applyTaskList(result)
+      if (isCurrent()) {
+        setTaskListError("")
+        applyTaskList(result)
+      }
     } catch (err) {
       if (isCurrent() && !isAbortError(err)) {
-        setError(err instanceof Error ? err.message : t.home.loadError)
+        setTaskListError(err instanceof Error ? err.message : t.home.loadError)
       }
     }
   }, [
@@ -392,7 +401,7 @@ export default function Home() {
                     className="h-9 pl-8"
                     value={taskQuery}
                     onChange={(event) => {
-                      setTaskQuery(event.target.value)
+                      setTaskQuery(truncateSearchQuery(event.target.value))
                       resetTaskPage()
                     }}
                     placeholder={t.home.taskSearchPlaceholder}
@@ -504,6 +513,12 @@ export default function Home() {
                 </div>
               </div>
             </div>
+
+            {taskListError ? (
+              <div className="mx-4 mt-4 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                {taskListError}
+              </div>
+            ) : null}
 
             {tasks.length === 0 ? (
               <div className="px-6 py-12 text-center text-sm text-muted-foreground">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,9 @@
 export const AUTH_UNAUTHORIZED_EVENT = "youdub:auth-unauthorized"
 
 const UNSAFE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"])
+const MAX_VALIDATION_ITEMS_INSPECTED = 20
+const MAX_VALIDATION_MESSAGES = 3
+const MAX_VALIDATION_MESSAGE_LENGTH = 240
 let csrfToken = ""
 
 export class ApiError extends Error {
@@ -31,6 +34,23 @@ function errorMessage(body: unknown, status: number) {
   if (body && typeof body === "object" && "detail" in body) {
     const detail = (body as { detail?: unknown }).detail
     if (typeof detail === "string" && detail.trim()) return detail
+    if (Array.isArray(detail)) {
+      const messages: string[] = []
+      for (const item of detail.slice(0, MAX_VALIDATION_ITEMS_INSPECTED)) {
+        if (item && typeof item === "object" && "msg" in item) {
+          const message = (item as { msg?: unknown }).msg
+          if (typeof message === "string" && message.trim()) {
+            const characters = Array.from(message.trim())
+            const normalized = characters.length > MAX_VALIDATION_MESSAGE_LENGTH
+              ? `${characters.slice(0, MAX_VALIDATION_MESSAGE_LENGTH - 1).join("")}…`
+              : message.trim()
+            if (!messages.includes(normalized)) messages.push(normalized)
+          }
+        }
+        if (messages.length >= MAX_VALIDATION_MESSAGES) break
+      }
+      if (messages.length > 0) return messages.join("; ")
+    }
   }
   return `Request failed: ${status}`
 }


### PR DESCRIPTION
## 问题

任务搜索没有与后端 200 字符上限同步；FastAPI 的结构化校验错误数组无法转换成可读文本；一次列表请求失败后，即使后续请求成功，错误横幅也不会消失。

## 根因

- 搜索状态接收任意长度输入，超过后端 `max_length=200` 后触发 422。
- 通用响应解析器只识别字符串 `detail`，没有安全处理 FastAPI 的 `{msg, input, ...}[]`。
- 列表加载错误与创建任务错误共用状态，成功轮询既不能安全清错，也不能避免误清另一类错误。

## 修复方案

- 搜索输入按 Unicode code point 截到 200，与 Python/Pydantic 的字符计数保持一致；避免 HTML `maxLength` 的 UTF-16 语义对 emoji 过早截断。
- 校验错误数组只抽取对象的公开 `msg`，忽略 `input/type/loc/ctx` 与裸字符串；最多检查 20 项、展示 3 条、每条 240 字符，畸形结构安全回退。
- 拆分列表错误与创建错误；只有当前有效的列表请求成功时才清除列表错误，列表轮询不会清除创建错误。
- 列表错误移到任务历史区域展示。

## 验证结果

- `npm --prefix apps/web test -- --reporter=verbose`：9 个测试通过
- `npm --prefix apps/web run lint`：通过
- `cd apps/web && ./node_modules/.bin/tsc --noEmit`：通过
- `npm --prefix apps/web run build`：通过
- `git diff --check`：通过

回归测试覆盖 201 个 emoji 截为 200 个并进入请求、结构化 422 可读展示且不泄露 `input`、数组裸字符串安全回退、成功请求清除旧列表错误、迟到旧成功不能清除新错误、列表恢复不能清除创建错误。

## 审查

两轮独立复审已完成。首轮发现的 Unicode 计数、脱敏旁路、无界错误文本与竞态测试缺口均已修复；复审确认无 P0–P2 阻断项。
