### PR TITLE
统一前后端上传视频格式契约

### DIFF
--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import Home from "@/app/page"
 import { LanguageProvider } from "@/lib/i18n"
+import uploadContract from "@/lib/upload-contract.json"
 
 const mocks = vi.hoisted(() => ({
   fetch: vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(),
@@ -59,6 +60,9 @@ describe("本地视频字幕选择", () => {
 
     const videoInput = screen.getByLabelText("本地视频文件") as HTMLInputElement
     const subtitleInput = screen.getByLabelText("已翻译 SRT 字幕（可选）") as HTMLInputElement
+    expect(videoInput.accept).toBe(uploadContract.video_extensions.join(","))
+    expect(videoInput.accept).not.toContain("video/*")
+    expect(videoInput.accept).not.toContain(".3gp")
     const videoA = new File(["video-a"], "video-a.mp4", { type: "video/mp4" })
     const subtitleA = new File(["subtitle-a"], "subtitle-a.srt", { type: "application/x-subrip" })
     const videoB = new File(["video-b"], "video-b.mp4", { type: "video/mp4" })

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -21,6 +21,7 @@ import {
 import { useI18n } from "@/lib/i18n"
 import { statusBadgeClass } from "@/lib/status"
 import { SerialPollingContext, useSerialPolling } from "@/lib/use-serial-polling"
+import uploadContract from "@/lib/upload-contract.json"
 import { AppHeader } from "@/components/app-header"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -42,6 +43,7 @@ import {
 
 const PAGE_SIZE_OPTIONS = [10, 20, 50, 100]
 const TASK_SEARCH_MAX_LENGTH = 200
+const LOCAL_VIDEO_ACCEPT = uploadContract.video_extensions.join(",")
 
 function truncateSearchQuery(value: string) {
   return Array.from(value).slice(0, TASK_SEARCH_MAX_LENGTH).join("")
@@ -283,7 +285,7 @@ export default function Home() {
                     ref={fileInputRef}
                     id="local-video"
                     type="file"
-                    accept="video/*,.mp4,.mov,.m4v,.mkv,.webm,.avi,.flv,.wmv"
+                    accept={LOCAL_VIDEO_ACCEPT}
                     onChange={selectLocalFile}
                     disabled={hasUrl}
                   />

--- a/apps/web/src/lib/upload-contract.json
+++ b/apps/web/src/lib/upload-contract.json
@@ -1,0 +1,12 @@
+{
+  "video_extensions": [
+    ".mp4",
+    ".mov",
+    ".m4v",
+    ".mkv",
+    ".webm",
+    ".avi",
+    ".flv",
+    ".wmv"
+  ]
+}

--- a/backend/tests/test_settings_and_api.py
+++ b/backend/tests/test_settings_and_api.py
@@ -1302,6 +1302,28 @@ def test_upload_local_video_creates_task_and_saved_file(monkeypatch, tmp_path):
     assert saved[0].read_bytes() == b"mp4data"
 
 
+def test_frontend_video_accept_contract_matches_backend_allowlist():
+    contract_path = (
+        Path(__file__).resolve().parents[2]
+        / "apps"
+        / "web"
+        / "src"
+        / "lib"
+        / "upload-contract.json"
+    )
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    extensions = contract["video_extensions"]
+
+    assert len(extensions) == len(set(extensions))
+    assert all(
+        extension.startswith(".") and extension == extension.lower()
+        for extension in extensions
+    )
+    assert set(extensions) == main.ALLOWED_VIDEO_SUFFIXES
+    for extension in extensions:
+        assert main._clean_upload_filename(f"clip{extension.upper()}") == f"clip{extension}"
+
+
 def test_upload_local_video_can_save_translated_srt(monkeypatch, tmp_path):
     configure_tmp_runtime(monkeypatch, tmp_path)
     enqueued: list[str] = []
@@ -1352,6 +1374,11 @@ def test_upload_local_video_can_save_translated_srt(monkeypatch, tmp_path):
         (
             {"direction": "en-zh", "execution_mode": "auto"},
             {"file": ("clip.txt", b"mp4data", "text/plain")},
+            "Unsupported video file type.",
+        ),
+        (
+            {"direction": "en-zh", "execution_mode": "auto"},
+            {"file": ("clip.3gp", b"mp4data", "video/mp4")},
             "Unsupported video file type.",
         ),
         (


### PR DESCRIPTION
## 问题

本地视频文件选择器包含 `video/*`。该 MIME 通配符会让浏览器开放 `.3gp`、`.ogv` 等后端明确拒绝的格式，用户直到上传后才收到 422。

## 根因

前端把宽泛 MIME 类型与显式扩展名做并集；后端则只按文件名末尾扩展名接受固定 8 种格式，两侧契约没有自动防漂移检查。

## 修复方案

- 新增机器可读的前端上传格式契约，固定为 `.mp4/.mov/.m4v/.mkv/.webm/.avi/.flv/.wmv`。
- 文件输入只使用这些扩展名 token，移除 `video/*`，不再向用户开放后端必然拒绝的格式。
- 后端安全校验保持不变，继续在建任务和写盘前按扩展名白名单拒绝非法文件。
- 新增跨栈契约测试：直接比对 JSON 与后端 `ALLOWED_VIDEO_SUFFIXES`，检查重复、大小写和点前缀，并验证所有大写扩展名可规范化。
- 增加 `.3gp` 伪报 `video/mp4` 仍返回 422 的回归测试，证明 MIME 不能绕过后端校验。

## 验证结果

- `.venv/bin/pytest backend/tests -q`：322 个测试通过（1 个既有弃用警告）
- `npm --prefix apps/web test -- --reporter=verbose`：9 个测试通过
- `npm --prefix apps/web run lint`：通过
- `cd apps/web && ./node_modules/.bin/tsc --noEmit`：通过
- `npm --prefix apps/web run build`：通过
- `git diff --check`：通过

## 审查

前后端独立复审均未发现代码层 P0–P2。复审提示的新 JSON 漏提交风险已通过显式暂存清单核对闭环，提交 `c525e00` 已包含该文件。
