### PR TITLE
增加 CI 质量与安全合并门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: 质量与安全门禁
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: 前端质量与安全
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: apps/web
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 配置 Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: 安装前端依赖
+        run: npm ci --ignore-scripts --no-audit --no-fund --registry=https://registry.npmmirror.com
+
+      - name: 运行前端测试
+        run: npm test -- --reporter=verbose
+
+      - name: 运行 ESLint
+        run: npm run lint
+
+      - name: 运行 TypeScript 检查
+        run: ./node_modules/.bin/tsc --noEmit
+
+      - name: 构建生产版本
+        run: npm run build
+
+      - name: 审计生产依赖
+        run: npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org
+
+  backend:
+    name: 后端测试
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: 配置 Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-test.txt
+
+      - name: 安装后端测试依赖
+        id: pip_aliyun
+        continue-on-error: true
+        run: python -m pip install -r backend/requirements-test.txt -i https://mirrors.aliyun.com/pypi/simple/
+
+      - name: 阿里云失败后使用清华镜像重试
+        if: steps.pip_aliyun.outcome == 'failure'
+        run: python -m pip install -r backend/requirements-test.txt -i https://pypi.tuna.tsinghua.edu.cn/simple/
+
+      - name: 检查轻量依赖边界
+        run: |
+          python -m pip check
+          python - <<'PY'
+          from importlib.util import find_spec
+
+          excluded = (
+              "torch", "whisper", "demucs", "voxcpm", "modelscope",
+              "librosa", "audiostretchy", "spacy", "openunmix",
+          )
+          installed = [name for name in excluded if find_spec(name) is not None]
+          if installed:
+              raise SystemExit(f"CI 测试环境意外安装了重型依赖: {', '.join(installed)}")
+          PY
+
+      - name: 运行后端全量测试
+        run: python -m pytest backend/tests -q

--- a/backend/app/adapters/audio.py
+++ b/backend/app/adapters/audio.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import librosa
 import numpy as np
 import soundfile as sf
-from audiostretchy.stretch import stretch_audio
 from pydub import AudioSegment
 
 BASE_FACTOR_MIN = 0.8
@@ -35,6 +33,8 @@ def split_audio_by_translation(vocals_file: Path, translation_file: Path, sessio
 
 
 def _audio_duration(file: Path) -> tuple[float, int]:
+    import librosa
+
     y, sr = librosa.load(str(file), sr=None)
     return len(y) / sr, sr
 
@@ -53,9 +53,13 @@ def _base_speed_factor(translation: list[dict], tts_files: list[Path]) -> float:
 
 
 def _stretch_segment(audio_file: Path, ratio: float, target_sec: float, cache_dir: Path) -> tuple[np.ndarray, int]:
+    import librosa
+
     if abs(ratio - 1.0) < SPEED_NOOP_EPSILON:
         y, sr = librosa.load(str(audio_file), sr=None)
         return y, sr
+    from audiostretchy.stretch import stretch_audio
+
     out_path = cache_dir / audio_file.name
     stretch_audio(str(audio_file), str(out_path), ratio=ratio)
     y, sr = librosa.load(str(out_path), sr=None)

--- a/backend/requirements-test.txt
+++ b/backend/requirements-test.txt
@@ -1,0 +1,17 @@
+# Lightweight CPU-only dependencies for the complete backend unit-test suite.
+# Keep this list aligned with imports exercised by backend/tests. Runtime ML
+# packages such as Torch, Whisper, OpenUnmix, librosa, AudioStretchy and VoxCPM
+# are mocked or lazily imported by tests and intentionally do not belong here.
+fastapi
+pydantic
+python-dotenv
+python-multipart
+pwdlib[argon2]>=0.3,<1
+openai
+yt-dlp
+requests
+numpy
+soundfile
+pydub
+pytest
+httpx[socks]


### PR DESCRIPTION
## 问题

仓库没有 GitHub Actions，也没有可作为合并门禁的前端质量、安全审计和后端测试检查。完整 Python 运行依赖包含 CUDA、Torch、Whisper、VoxCPM 等重型组件，直接用于普通 CI 不可维护。

## 根因

- 前端 lint、TypeScript、测试、构建和 npm 安全审计只依赖人工执行。
- 后端只有会回引完整生产依赖的 requirements，没有单元/API 测试专用的轻量依赖集合。
- 部分未被当前单元测试执行的音频库在模块导入阶段加载，迫使测试环境安装 SciPy/Numba/LLVM 等重型传递依赖。

## 修复方案

- 新增 `质量与安全门禁` workflow，在 PR 与 main push 上运行两个稳定检查：`前端质量与安全`、`后端测试`。
- 前端使用 Node 22 和干净 `npm ci`，依次运行 9 个测试、ESLint、TypeScript、生产构建，以及显式指向 npm 官方源的生产依赖 audit；high/critical 会使检查失败。
- 后端使用 Python 3.12 和独立 `backend/requirements-test.txt`，完整运行 322 个测试，不跳过任何测试。
- 将 librosa/AudioStretchy 改为实际音频处理函数调用时再导入，使字幕/API 单元测试不需要无关重包，不改变生产调用路径。
- 后端安装先使用阿里云镜像，仅失败时通过独立命令重试清华镜像；随后运行 `pip check` 和重型依赖 guard。
- 所有官方 action 固定到已核对发布标签的完整提交 SHA；token 仅有只读内容权限，checkout 不持久化凭据，不读取 secrets。

## 验证结果

- 无 `.env/env.txt` 的临时 worktree + 全新 Python 3.12 venv：322 个后端测试通过，`pip check` 与重型依赖 guard 通过。
- 全新前端安装：9 个测试、ESLint、TypeScript、Next.js 生产构建通过。
- `npm audit --omit=dev --audit-level=high --registry=https://registry.npmjs.org`：退出码 0，无 high/critical；报告 2 个 Next 内嵌 PostCSS moderate。当前应用不接收、解析并内嵌用户 CSS，该公告要求的可控 CSS 输入链路不可达；不使用 `--force` 降级 Next。
- workflow YAML 与 heredoc 结构已解析和等价执行验证。
- `git diff --check`：通过。

## 后续门禁配置

本 PR 的两个检查首次成功后，将为 main 启用严格必需检查：

- `前端质量与安全`
- `后端测试`

并启用管理员同样受约束、禁止 force push 与删除。只有外部保护规则落地后，本项才视为完成。

## 明确后置

Python 版本锁定按 Goal 要求不在本分支实施。本项只提供经干净 CPU 环境验证的轻量直接依赖列表；constraints/lock、CPU/CUDA 矩阵和生产/开发依赖拆分将在单独中文 Issue 中跟踪。

## 审查

两路独立审查确认代码与 workflow 无 P0–P2 阻断项；未跟踪新文件风险已通过提交 `dc0925d` 的暂存清单核对闭环。
