### PR TITLE
修正 README 前端依赖安装命令

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -144,7 +144,9 @@ py -3.12 -m venv .venv
 Frontend:
 
 ```powershell
-npm --prefix apps/web install --registry=https://registry.npmmirror.com
+Push-Location apps/web
+npm ci --registry=https://registry.npmmirror.com
+Pop-Location
 ```
 
 #### macOS / Linux / WSL2
@@ -160,7 +162,7 @@ python3.12 -m venv .venv
 Frontend:
 
 ```bash
-npm --prefix apps/web install --registry=https://registry.npmmirror.com
+(cd apps/web && npm ci --registry=https://registry.npmmirror.com)
 ```
 
 Use Aliyun first. If a specific Python package is temporarily unavailable there, retry only that package with the Tsinghua mirror instead of mixing multiple mirrors in one resolver command.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ py -3.12 -m venv .venv
 前端依赖：
 
 ```powershell
-npm --prefix apps/web install --registry=https://registry.npmmirror.com
+Push-Location apps/web
+npm ci --registry=https://registry.npmmirror.com
+Pop-Location
 ```
 
 #### macOS / Linux / WSL2
@@ -160,7 +162,7 @@ python3.12 -m venv .venv
 前端依赖：
 
 ```bash
-npm --prefix apps/web install --registry=https://registry.npmmirror.com
+(cd apps/web && npm ci --registry=https://registry.npmmirror.com)
 ```
 
 如果 Aliyun 镜像中某个 Python 包暂时不可用，再单独对失败的包使用 Tsinghua 源重试；不要把多个镜像混在同一条 resolver 命令里。


### PR DESCRIPTION
## 修改内容

- 将中英文 README 的前端依赖安装命令改为在 `apps/web` 目录执行 `npm ci`
- PowerShell 使用 `Push-Location` / `Pop-Location`，macOS、Linux 和 WSL2 使用子 shell，确保后续命令仍从仓库根目录执行
- 保留 npmmirror registry 配置

## 验证

- 实际执行 `(cd apps/web && npm ci --registry=https://registry.npmmirror.com)`，成功安装 714 个包
- 执行前后 `apps/web/package.json` 与 `apps/web/package-lock.json` 哈希一致
- `git diff --check` 通过

Closes #116