### PR TITLE
修复 Windows TorchCodec 的 FFmpeg DLL 加载（#117）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ WHISPER_DEVICE=
 # use ffmpeg-full instead:
 # FFMPEG_PATH=/opt/homebrew/opt/ffmpeg-full/bin/ffmpeg
 # FFPROBE_PATH=/opt/homebrew/opt/ffmpeg-full/bin/ffprobe
+# Windows: use a shared/full-shared build. FFMPEG_PATH's directory must contain
+# av*.dll files; YouDub registers that directory for Python's DLL loader.
 # FFMPEG_PATH=C:\path\to\ffmpeg.exe
 # FFPROBE_PATH=C:\path\to\ffprobe.exe
 

--- a/README.en.md
+++ b/README.en.md
@@ -102,7 +102,23 @@ winget install Gyan.FFmpeg.Shared
 winget install OpenJS.NodeJS.LTS
 ```
 
-On Windows, install a shared/full-shared FFmpeg build. After installation, confirm that `ffmpeg -version` and `ffprobe -version` work and that the FFmpeg DLL directory is available on `PATH`; otherwise the audio separation stage may fail to load the TorchCodec/FFmpeg runtime libraries.
+Windows requires a shared/full-shared FFmpeg build. Run the following checks from that build's `bin` directory. The `av*.dll` command should list at least `avcodec-*.dll`, `avformat-*.dll`, and `avutil-*.dll`. A directory containing only `ffmpeg.exe`, `ffplay.exe`, and `ffprobe.exe` is a static build and cannot provide TorchCodec's runtime libraries.
+
+```powershell
+$ffmpegBin = "C:\path\to\ffmpeg\bin"
+Get-ChildItem "$ffmpegBin\av*.dll"
+& "$ffmpegBin\ffmpeg.exe" -version
+& "$ffmpegBin\ffprobe.exe" -version
+```
+
+Add the actual paths to `.env` in the repository root:
+
+```dotenv
+FFMPEG_PATH=C:/path/to/ffmpeg/bin/ffmpeg.exe
+FFPROBE_PATH=C:/path/to/ffmpeg/bin/ffprobe.exe
+```
+
+Python 3.8+ requires applications to register DLL search directories explicitly; changing `PATH` alone does not guarantee that TorchCodec can find these DLLs. At startup, YouDub reads `FFMPEG_PATH`, checks for `av*.dll` in the same directory, and registers it with `os.add_dll_directory()`. Configuration errors are reported immediately during startup.
 
 ```bash
 # Ubuntu / Debian / WSL2

--- a/README.en.md
+++ b/README.en.md
@@ -111,14 +111,7 @@ Get-ChildItem "$ffmpegBin\av*.dll"
 & "$ffmpegBin\ffprobe.exe" -version
 ```
 
-Add the actual paths to `.env` in the repository root:
-
-```dotenv
-FFMPEG_PATH=C:/path/to/ffmpeg/bin/ffmpeg.exe
-FFPROBE_PATH=C:/path/to/ffmpeg/bin/ffprobe.exe
-```
-
-Python 3.8+ requires applications to register DLL search directories explicitly; changing `PATH` alone does not guarantee that TorchCodec can find these DLLs. At startup, YouDub reads `FFMPEG_PATH`, checks for `av*.dll` in the same directory, and registers it with `os.add_dll_directory()`. Configuration errors are reported immediately during startup.
+Keep the verified `bin` directory handy and add its actual path after creating `.env` in step 4. Python 3.8+ requires applications to register DLL search directories explicitly; changing `PATH` alone does not guarantee that TorchCodec can find these DLLs. At startup, YouDub reads `FFMPEG_PATH`, checks for `av*.dll` in the same directory, and registers it with `os.add_dll_directory()`. Configuration errors are reported immediately during startup.
 
 ```bash
 # Ubuntu / Debian / WSL2
@@ -223,6 +216,13 @@ cp env.txt.example .env
 
 The application reads `.env` at runtime. Do not commit API keys, cookies, downloaded media, or generated artifacts.
 
+On Windows, add the shared/full-shared FFmpeg paths verified in step 1 to the `.env` file you just created:
+
+```dotenv
+FFMPEG_PATH=C:/path/to/ffmpeg/bin/ffmpeg.exe
+FFPROBE_PATH=C:/path/to/ffmpeg/bin/ffprobe.exe
+```
+
 Authentication is mandatory by default, and the backend refuses to start without `YOUDUB_AUTH_PASSWORD_HASH`. Generate an Argon2id hash locally with an interactive password prompt; these commands do not put the plaintext password in shell history.
 
 Windows PowerShell:
@@ -251,6 +251,7 @@ Common environment variables:
 | `YOUDUB_AUTH_COOKIE_SAMESITE` | Session Cookie SameSite policy: `lax` or `strict`; `strict` is recommended with the same-origin proxy. |
 | `DEVICE` | Model runtime device, for example `auto`, `cuda`, `cuda:0`, `mps`, `mps:0`, or `cpu`; `auto` selects CUDA, then MPS, then CPU. |
 | `DEMUCS_DEVICE` / `WHISPER_DEVICE` | Optional component-level device overrides. Empty values use `DEVICE`. Whisper falls back to CPU when MPS is selected because word timestamp alignment depends on float64 DTW, which MPS does not support. |
+| `FFMPEG_PATH` / `FFPROBE_PATH` | Optional full paths to the media binaries. On Windows with TorchCodec, `FFMPEG_PATH` must point to a shared/full-shared build. |
 | `OPENAI_BASE_URL` | OpenAI-compatible API endpoint, for example `https://api.openai.com/v1`. |
 | `OPENAI_API_KEY` | API key used by the translation stage. |
 | `OPENAI_MODEL` | Chat Completions model used by the translation stage. |

--- a/README.md
+++ b/README.md
@@ -111,14 +111,7 @@ Get-ChildItem "$ffmpegBin\av*.dll"
 & "$ffmpegBin\ffprobe.exe" -version
 ```
 
-将实际路径写入项目根目录的 `.env`：
-
-```dotenv
-FFMPEG_PATH=C:/path/to/ffmpeg/bin/ffmpeg.exe
-FFPROBE_PATH=C:/path/to/ffmpeg/bin/ffprobe.exe
-```
-
-Python 3.8+ 的 DLL 加载规则需要应用显式注册搜索目录；单独修改 `PATH` 无法保证 TorchCodec 找到这些 DLL。YouDub 启动时会读取 `FFMPEG_PATH`，检查同目录的 `av*.dll`，并通过 `os.add_dll_directory()` 注册该目录。配置错误会在启动阶段直接给出原因。
+记下通过检查的 `bin` 目录；在第 4 步创建 `.env` 后填入该实际路径。Python 3.8+ 的 DLL 加载规则需要应用显式注册搜索目录；单独修改 `PATH` 无法保证 TorchCodec 找到这些 DLL。YouDub 启动时会读取 `FFMPEG_PATH`，检查同目录的 `av*.dll`，并通过 `os.add_dll_directory()` 注册该目录。配置错误会在启动阶段直接给出原因。
 
 ```bash
 # Ubuntu / Debian / WSL2
@@ -223,6 +216,13 @@ cp env.txt.example .env
 
 应用运行时读取 `.env`。不要提交 API key、Cookie、下载视频或生成产物。
 
+Windows 用户把第 1 步确认过的 shared/full-shared FFmpeg 实际路径写入刚创建的 `.env`：
+
+```dotenv
+FFMPEG_PATH=C:/path/to/ffmpeg/bin/ffmpeg.exe
+FFPROBE_PATH=C:/path/to/ffmpeg/bin/ffprobe.exe
+```
+
 后端默认强制认证；`YOUDUB_AUTH_PASSWORD_HASH` 未配置时会拒绝启动。请在本机交互式输入访问密码并生成 Argon2id 哈希，命令不会把明文密码写入 shell 历史：
 
 Windows PowerShell：
@@ -251,6 +251,7 @@ macOS / Linux / WSL2：
 | `YOUDUB_AUTH_COOKIE_SAMESITE` | 会话 Cookie 的 SameSite 策略，可选 `lax` 或 `strict`；同源代理部署建议 `strict`。 |
 | `DEVICE` | 模型运行设备，例如 `auto`、`cuda`、`cuda:0`、`mps`、`mps:0` 或 `cpu`；`auto` 按 CUDA、MPS、CPU 顺序选择。 |
 | `DEMUCS_DEVICE` / `WHISPER_DEVICE` | 可选组件级设备覆盖；留空时使用 `DEVICE`。Whisper 选择 MPS 时会退回 CPU，因为词级时间戳对齐依赖 MPS 不支持的 float64 DTW。 |
+| `FFMPEG_PATH` / `FFPROBE_PATH` | 可选的媒体程序完整路径；Windows 上使用 TorchCodec 时，`FFMPEG_PATH` 必须指向 shared/full-shared 构建。 |
 | `OPENAI_BASE_URL` | OpenAI 兼容 API 地址，例如 `https://api.openai.com/v1`。 |
 | `OPENAI_API_KEY` | 翻译阶段使用的 API key。 |
 | `OPENAI_MODEL` | 翻译阶段使用的 Chat Completions 模型。 |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,23 @@ winget install Gyan.FFmpeg.Shared
 winget install OpenJS.NodeJS.LTS
 ```
 
-Windows 上建议安装 FFmpeg 的 shared/full-shared 版本；安装后请确认 `ffmpeg -version` 和 `ffprobe -version` 可用，并且 FFmpeg 的 DLL 目录在 `PATH` 中，否则音频分离阶段可能无法加载 TorchCodec/FFmpeg 运行库。
+Windows 必须安装 FFmpeg 的 shared/full-shared 版本。进入该版本的 `bin` 目录后执行以下检查；`av*.dll` 至少应列出 `avcodec-*.dll`、`avformat-*.dll` 和 `avutil-*.dll`。只有 `ffmpeg.exe`、`ffplay.exe`、`ffprobe.exe` 且没有 `av*.dll` 的目录属于静态构建，TorchCodec 无法使用它提供运行库。
+
+```powershell
+$ffmpegBin = "C:\path\to\ffmpeg\bin"
+Get-ChildItem "$ffmpegBin\av*.dll"
+& "$ffmpegBin\ffmpeg.exe" -version
+& "$ffmpegBin\ffprobe.exe" -version
+```
+
+将实际路径写入项目根目录的 `.env`：
+
+```dotenv
+FFMPEG_PATH=C:/path/to/ffmpeg/bin/ffmpeg.exe
+FFPROBE_PATH=C:/path/to/ffmpeg/bin/ffprobe.exe
+```
+
+Python 3.8+ 的 DLL 加载规则需要应用显式注册搜索目录；单独修改 `PATH` 无法保证 TorchCodec 找到这些 DLL。YouDub 启动时会读取 `FFMPEG_PATH`，检查同目录的 `av*.dll`，并通过 `os.add_dll_directory()` 注册该目录。配置错误会在启动阶段直接给出原因。
 
 ```bash
 # Ubuntu / Debian / WSL2

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import threading
 from pathlib import Path
 
@@ -11,11 +12,44 @@ from . import runtime_security
 REPO_ROOT = Path(__file__).resolve().parents[2]
 runtime_security.apply_private_umask()
 
+_FFMPEG_DLL_DIRECTORY_HANDLE: object | None = None
+
+
+def configure_windows_ffmpeg_dll_directory() -> None:
+    global _FFMPEG_DLL_DIRECTORY_HANDLE
+    if sys.platform != "win32" or _FFMPEG_DLL_DIRECTORY_HANDLE is not None:
+        return
+
+    configured = os.getenv("FFMPEG_PATH", "").strip()
+    if not configured:
+        return
+
+    ffmpeg_path = Path(configured).expanduser().resolve()
+    if not ffmpeg_path.is_file():
+        raise RuntimeError(
+            f"FFMPEG_PATH does not point to an existing ffmpeg.exe: {ffmpeg_path}"
+        )
+
+    dll_dir = ffmpeg_path.parent
+    if not any(dll_dir.glob("av*.dll")):
+        raise RuntimeError(
+            "FFMPEG_PATH must point to a Windows shared/full-shared FFmpeg build; "
+            f"no av*.dll files were found in {dll_dir}"
+        )
+
+    try:
+        _FFMPEG_DLL_DIRECTORY_HANDLE = os.add_dll_directory(str(dll_dir))
+    except OSError as exc:
+        raise RuntimeError(
+            f"Failed to register the FFmpeg DLL directory: {dll_dir}"
+        ) from exc
+
 
 def _load_runtime_environment(repo_root: Path) -> None:
     runtime_security.prepare_repository_root(repo_root)
     runtime_security.secure_secret_aliases(repo_root / ".env", repo_root / "env.txt")
     load_dotenv(repo_root / ".env")
+    configure_windows_ffmpeg_dll_directory()
 
 
 _load_runtime_environment(REPO_ROOT)

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from backend.app import config
+
+
+def test_configure_windows_ffmpeg_dll_directory_uses_configured_shared_build(
+    monkeypatch, tmp_path
+):
+    ffmpeg_dir = tmp_path / "ffmpeg" / "bin"
+    ffmpeg_dir.mkdir(parents=True)
+    ffmpeg_path = ffmpeg_dir / "ffmpeg.exe"
+    ffmpeg_path.write_bytes(b"")
+    (ffmpeg_dir / "avcodec-63.dll").write_bytes(b"")
+    dll_handle = object()
+    registered: list[str] = []
+
+    monkeypatch.setattr(config.sys, "platform", "win32")
+    monkeypatch.setenv("FFMPEG_PATH", str(ffmpeg_path))
+    monkeypatch.setattr(config, "_FFMPEG_DLL_DIRECTORY_HANDLE", None)
+    monkeypatch.setattr(
+        config.os,
+        "add_dll_directory",
+        lambda path: registered.append(path) or dll_handle,
+        raising=False,
+    )
+
+    config.configure_windows_ffmpeg_dll_directory()
+    config.configure_windows_ffmpeg_dll_directory()
+
+    assert registered == [str(ffmpeg_dir.resolve())]
+    assert config._FFMPEG_DLL_DIRECTORY_HANDLE is dll_handle
+
+
+def test_configure_windows_ffmpeg_dll_directory_rejects_static_build(
+    monkeypatch, tmp_path
+):
+    ffmpeg_path = tmp_path / "ffmpeg.exe"
+    ffmpeg_path.write_bytes(b"")
+
+    monkeypatch.setattr(config.sys, "platform", "win32")
+    monkeypatch.setenv("FFMPEG_PATH", str(ffmpeg_path))
+    monkeypatch.setattr(config, "_FFMPEG_DLL_DIRECTORY_HANDLE", None)
+
+    try:
+        config.configure_windows_ffmpeg_dll_directory()
+    except RuntimeError as exc:
+        assert "av*.dll" in str(exc)
+    else:
+        raise AssertionError("static FFmpeg build should be rejected")
+
+
+def test_configure_windows_ffmpeg_dll_directory_skips_other_platforms(monkeypatch):
+    monkeypatch.setattr(config.sys, "platform", "darwin")
+    monkeypatch.setenv("FFMPEG_PATH", "/missing/ffmpeg")
+    monkeypatch.setattr(config, "_FFMPEG_DLL_DIRECTORY_HANDLE", None)
+
+    config.configure_windows_ffmpeg_dll_directory()
+
+    assert config._FFMPEG_DLL_DIRECTORY_HANDLE is None


### PR DESCRIPTION
## 变更

- 在加载 `.env` 后读取 `FFMPEG_PATH`，并在 Windows 上通过 `os.add_dll_directory()` 注册 FFmpeg DLL 目录
- 保留 DLL 目录句柄，并在启动阶段拒绝路径错误或缺少 `av*.dll` 的静态构建
- 更新中英文 README 与 `.env.example`，给出 shared/full-shared 判据和配置示例
- 新增 Windows 注册、静态构建拒绝及非 Windows 跳过的回归测试

## 验证

- `.venv/bin/python -m pytest backend/tests -q`：325 passed

Closes #117