### PR TITLE
拒绝静默截短越界原音片段

### DIFF
--- a/backend/app/adapters/voxcpm.py
+++ b/backend/app/adapters/voxcpm.py
@@ -115,12 +115,18 @@ def _write_original_target_audio(
         raise ValueError(f"Original audio does not cover target segment {start}-{end} ms")
 
     with sf.SoundFile(original_vocals_file) as source:
-        start_frame = min(source.frames, max(0, int(start * source.samplerate / 1000)))
-        end_frame = min(source.frames, int(end * source.samplerate / 1000))
+        start_frame = max(0, int(start * source.samplerate / 1000))
+        end_frame = int(end * source.samplerate / 1000)
+        available_duration_ms = source.frames / source.samplerate * 1000
+        range_error = (
+            f"Original audio does not cover target segment {start}-{end} ms: "
+            f"requested frames {start_frame}-{end_frame}, available audio is "
+            f"{source.frames} frames ({available_duration_ms:.3f} ms)"
+        )
+        if start_frame >= source.frames or end_frame > source.frames:
+            raise ValueError(range_error)
         if end_frame <= start_frame:
-            raise ValueError(
-                f"Original audio does not cover target segment {start}-{end} ms"
-            )
+            raise ValueError(range_error)
         source.seek(start_frame)
         frames = source.read(
             end_frame - start_frame,
@@ -128,9 +134,7 @@ def _write_original_target_audio(
             always_2d=True,
         )
         if len(frames) <= 0:
-            raise ValueError(
-                f"Original audio does not cover target segment {start}-{end} ms"
-            )
+            raise ValueError(range_error)
 
         encoded = io.BytesIO()
         sf.write(

--- a/backend/app/adapters/voxcpm.py
+++ b/backend/app/adapters/voxcpm.py
@@ -116,15 +116,21 @@ def _write_original_target_audio(
 
     with sf.SoundFile(original_vocals_file) as source:
         start_frame = max(0, int(start * source.samplerate / 1000))
-        end_frame = int(end * source.samplerate / 1000)
+        requested_end_frame = int(end * source.samplerate / 1000)
+        end_frame = requested_end_frame
         available_duration_ms = source.frames / source.samplerate * 1000
         range_error = (
             f"Original audio does not cover target segment {start}-{end} ms: "
-            f"requested frames {start_frame}-{end_frame}, available audio is "
+            f"requested frames {start_frame}-{requested_end_frame}, available audio is "
             f"{source.frames} frames ({available_duration_ms:.3f} ms)"
         )
-        if start_frame >= source.frames or end_frame > source.frames:
+        if start_frame >= source.frames:
             raise ValueError(range_error)
+        overflow_frames = requested_end_frame - source.frames
+        if overflow_frames > 0:
+            if overflow_frames * 1000 >= source.samplerate:
+                raise ValueError(range_error)
+            end_frame = source.frames
         if end_frame <= start_frame:
             raise ValueError(range_error)
         source.seek(start_frame)

--- a/backend/app/adapters/voxcpm.py
+++ b/backend/app/adapters/voxcpm.py
@@ -126,9 +126,9 @@ def _write_original_target_audio(
         )
         if start_frame >= source.frames:
             raise ValueError(range_error)
-        overflow_frames = requested_end_frame - source.frames
-        if overflow_frames > 0:
-            if overflow_frames * 1000 >= source.samplerate:
+        overflow_scaled = end * source.samplerate - source.frames * 1000
+        if overflow_scaled > 0:
+            if overflow_scaled >= source.samplerate:
                 raise ValueError(range_error)
             end_frame = source.frames
         if end_frame <= start_frame:

--- a/backend/tests/test_voxcpm.py
+++ b/backend/tests/test_voxcpm.py
@@ -280,6 +280,65 @@ def test_original_target_audio_writes_exact_private_range(tmp_path):
         assert stat.S_IMODE(output.parent.stat().st_mode) == 0o700
 
 
+def test_original_target_audio_rejects_partially_out_of_range(tmp_path):
+    source = _make_synthetic_wav(
+        tmp_path / "media" / "audio_vocals.wav", duration_ms=500
+    )
+    output = tmp_path / "segments" / "tts" / "0001.wav"
+
+    with pytest.raises(ValueError) as exc_info:
+        voxcpm_mod._write_original_target_audio(
+            output,
+            {"start_time": 250, "end_time": 750},
+            source,
+        )
+
+    message = str(exc_info.value)
+    assert "250-750 ms" in message
+    assert "requested frames 4000-12000" in message
+    assert "8000 frames (500.000 ms)" in message
+    assert not output.exists()
+
+
+def test_original_target_audio_rejects_fully_out_of_range(tmp_path):
+    source = _make_synthetic_wav(
+        tmp_path / "media" / "audio_vocals.wav", duration_ms=500
+    )
+    output = tmp_path / "segments" / "tts" / "0001.wav"
+
+    with pytest.raises(ValueError) as exc_info:
+        voxcpm_mod._write_original_target_audio(
+            output,
+            {"start_time": 600, "end_time": 750},
+            source,
+        )
+
+    message = str(exc_info.value)
+    assert "600-750 ms" in message
+    assert "requested frames 9600-12000" in message
+    assert "8000 frames (500.000 ms)" in message
+    assert not output.exists()
+
+
+def test_original_target_audio_accepts_end_at_source_boundary(tmp_path):
+    source = _make_synthetic_wav(
+        tmp_path / "media" / "audio_vocals.wav", duration_ms=500
+    )
+    output = tmp_path / "segments" / "tts" / "0001.wav"
+
+    voxcpm_mod._write_original_target_audio(
+        output,
+        {"start_time": 250, "end_time": 500},
+        source,
+    )
+
+    copied, sample_rate = sf.read(output, dtype="float32")
+    source_samples, _ = sf.read(source, dtype="float32")
+    assert sample_rate == 16000
+    assert len(copied) == 4000
+    assert np.allclose(copied, source_samples[4000:8000], atol=2 / 32768)
+
+
 @pytest.mark.skipif(
     not runtime_security.POSIX_STRONG_PERMISSIONS,
     reason="symlink-safe private writes require POSIX semantics",

--- a/backend/tests/test_voxcpm.py
+++ b/backend/tests/test_voxcpm.py
@@ -339,6 +339,45 @@ def test_original_target_audio_accepts_end_at_source_boundary(tmp_path):
     assert np.allclose(copied, source_samples[4000:8000], atol=2 / 32768)
 
 
+def test_original_target_audio_accepts_sub_millisecond_rounded_tail(tmp_path):
+    source = tmp_path / "media" / "audio_vocals.wav"
+    source.parent.mkdir(parents=True)
+    source_samples = np.linspace(-0.75, 0.75, 44127, dtype=np.float32)
+    sf.write(source, source_samples, 44100)
+    output = tmp_path / "segments" / "tts" / "0001.wav"
+
+    voxcpm_mod._write_original_target_audio(
+        output,
+        {"start_time": 0, "end_time": 1001},
+        source,
+    )
+
+    copied, sample_rate = sf.read(output, dtype="float32")
+    assert sample_rate == 44100
+    assert len(copied) == 44127
+    assert np.allclose(copied, source_samples, atol=2 / 32768)
+
+
+def test_original_target_audio_rejects_one_millisecond_tail_overflow(tmp_path):
+    source = _make_synthetic_wav(
+        tmp_path / "media" / "audio_vocals.wav", duration_ms=500
+    )
+    output = tmp_path / "segments" / "tts" / "0001.wav"
+
+    with pytest.raises(ValueError) as exc_info:
+        voxcpm_mod._write_original_target_audio(
+            output,
+            {"start_time": 0, "end_time": 501},
+            source,
+        )
+
+    message = str(exc_info.value)
+    assert "0-501 ms" in message
+    assert "requested frames 0-8016" in message
+    assert "8000 frames (500.000 ms)" in message
+    assert not output.exists()
+
+
 @pytest.mark.skipif(
     not runtime_security.POSIX_STRONG_PERMISSIONS,
     reason="symlink-safe private writes require POSIX semantics",

--- a/backend/tests/test_voxcpm.py
+++ b/backend/tests/test_voxcpm.py
@@ -378,6 +378,29 @@ def test_original_target_audio_rejects_one_millisecond_tail_overflow(tmp_path):
     assert not output.exists()
 
 
+def test_original_target_audio_rejects_quantized_one_millisecond_tail_overflow(
+    tmp_path,
+):
+    source = tmp_path / "media" / "audio_vocals.wav"
+    source.parent.mkdir(parents=True)
+    source_samples = np.linspace(-0.75, 0.75, 22050, dtype=np.float32)
+    sf.write(source, source_samples, 44100)
+    output = tmp_path / "segments" / "tts" / "0001.wav"
+
+    with pytest.raises(ValueError) as exc_info:
+        voxcpm_mod._write_original_target_audio(
+            output,
+            {"start_time": 0, "end_time": 501},
+            source,
+        )
+
+    message = str(exc_info.value)
+    assert "0-501 ms" in message
+    assert "requested frames 0-22094" in message
+    assert "22050 frames (500.000 ms)" in message
+    assert not output.exists()
+
+
 @pytest.mark.skipif(
     not runtime_security.POSIX_STRONG_PERMISSIONS,
     reason="symlink-safe private writes require POSIX semantics",


### PR DESCRIPTION
## 背景

这是 [#121](https://github.com/liuzhao1225/YouDub-webui/pull/121) 合并后的 review 跟进。`_write_original_target_audio` 原先会把超过 `original_vocals_file` 尾部的 `end_frame` 截到 `source.frames`，导致部分越界请求静默生成较短原音片段。

感谢 @lyk-bit 在 #112 中提供初始实现和思路

相关实现来源与上下文：

- [#121：收录非语言原音回填与 audio_mode 契约](https://github.com/liuzhao1225/YouDub-webui/pull/121)
- [f7268d3c：修复 TTS 原音回填与安全写入](https://github.com/liuzhao1225/YouDub-webui/commit/f7268d3c60c184a4f51345c3eea70947238e3947)
- [6f7fd083：补充显式 audio_mode 与声音字幕契约](https://github.com/liuzhao1225/YouDub-webui/commit/6f7fd083b3a0c62c2008089b33600ad010288604)

## 改动

- 在读取原音前计算并保留完整请求帧范围。
- 请求起点越界，或尾部溢出达到 1ms 及以上时，直接抛出 `ValueError`。
- 仅允许 Pydub/ASR 整毫秒舍入造成的严格小于 1ms 尾部溢出，并 clamp 到源音频末帧。
- 使用未量化整数有理式 `end * samplerate - source.frames * 1000` 判断溢出时长，避免先 floor 到整帧掩盖恰好 1ms 的越界。
- 错误信息包含请求毫秒区间、原始请求帧区间、源音频总帧数和可用时长。
- 不补静音，不为真实越界生成被截短的输出文件。

## Review 跟进

- 44.1kHz、44127 帧音频被表示为 1001ms 时，未量化溢出为 17100/44100ms，约 0.388ms，允许 clamp 并完整输出。
- 44.1kHz、22050 帧音频精确为 500ms，请求到 501ms 时，虽然 floor 后只多 44 帧，未量化溢出仍恰好为 1ms，继续显式拒绝。
- 16kHz、8000 帧的 500ms 音频请求到 501ms 时同样显式拒绝。

## 基线同步

提交前已普通 merge 最新 `origin/main`，当前基线包含 #123，SHA 为 `5dfbea1c7b53f59847c3a6d0055cb059a417b394`。

## 验证

- `backend/tests/test_voxcpm.py`：19 项通过。
- 后端全量测试：354 项通过。
- `git diff --check`：通过。