### PR TITLE
chore: 忽略 macOS 的 .DS_Store 文件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+# macOS Finder metadata
+.DS_Store
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore


### PR DESCRIPTION
## 变更说明

- 在根目录 `.gitignore` 中添加 `.DS_Store` 忽略规则。
- 避免 macOS Finder 生成的本地元数据文件被意外提交。

## 验证

- 已确认根目录及嵌套目录中的 `.DS_Store` 均会被 Git 忽略。